### PR TITLE
토스트 퇴장 애니메이션과 자동 닫힘 안정화

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,7 +1,79 @@
 import { act, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, describe, expect, it } from "vitest";
-import { AppShellFallback } from "./App";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "./App";
+import { DEFAULT_APP_PREFERENCES } from "./lib/preview-preferences";
+
+vi.mock("./components/dialog/UnsavedChangesDialog", () => ({
+  UnsavedChangesDialog: () => null,
+}));
+
+vi.mock("./components/welcome/WelcomeScreen", () => ({
+  WelcomeScreen: () => null,
+}));
+
+vi.mock("./hooks/useAppMenuController", () => ({
+  useAppMenuController: () => undefined,
+}));
+
+vi.mock("./hooks/useDocumentSession", () => ({
+  useDocumentSession: () => ({
+    applyOpenedDocument: () => undefined,
+    clearRecentFilesList: () => undefined,
+    closeCurrentDocument: () => undefined,
+    createNewDocument: () => undefined,
+    documentStore: {},
+    editorDocumentKey: 0,
+    fileInputRef: { current: null },
+    filePath: null,
+    filename: null,
+    handleOpenFile: () => undefined,
+    isWelcomeVisible: false,
+    loadRecentDocument: async () => null,
+    openWithPicker: async () => null,
+    openWithPickerWithoutShowingWindow: async () => null,
+    recentFiles: [],
+    savedRevision: 0,
+    saveDocument: async () => false,
+  }),
+}));
+
+vi.mock("./components/workspace/EditorWorkspace", () => ({
+  EditorWorkspace: ({ onPathCopy }: { onPathCopy: () => void }) => (
+    <button onClick={onPathCopy} type="button">
+      Trigger toast
+    </button>
+  ),
+}));
+
+vi.mock("./hooks/useNativeWindowState", () => ({
+  useNativeWindowState: () => ({
+    ensureWindowVisible: async () => undefined,
+    handleEditorFocusChange: () => undefined,
+    hideWindow: async () => undefined,
+  }),
+}));
+
+vi.mock("./lib/document-store", () => ({
+  useDocumentDirty: () => false,
+}));
+
+vi.mock("./lib/debug-log", () => ({
+  clearDebugLog: async () => undefined,
+}));
+
+vi.mock("./lib/native-close-sheet", () => ({
+  showNativeCloseSheet: async () => "cancel",
+}));
+
+vi.mock("./lib/native-open-document", () => ({
+  setupNativeOpenDocumentListener: async () => () => undefined,
+}));
+
+vi.mock("./lib/theme", () => ({
+  applyTheme: () => undefined,
+  subscribeToSystemTheme: () => () => undefined,
+}));
 
 function createTestRenderer() {
   const container = document.createElement("div");
@@ -26,23 +98,53 @@ function createTestRenderer() {
 
 const cleanupHandlers: Array<() => void> = [];
 
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
 afterEach(() => {
   while (cleanupHandlers.length > 0) {
     cleanupHandlers.pop()?.();
   }
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
 });
 
-describe("AppShellFallback", () => {
-  it("announces that the editor workspace is loading", () => {
+describe("App toast lifecycle", () => {
+  it("automatically transitions the toast to exit and then removes it", async () => {
     const renderer = createTestRenderer();
     cleanupHandlers.push(() => renderer.cleanup());
 
-    renderer.render(<AppShellFallback />);
+    await act(async () => {
+      renderer.render(<App initialPreferences={DEFAULT_APP_PREFERENCES} />);
+    });
 
-    const fallback = renderer.container.querySelector("[role='status']");
-    expect(fallback?.getAttribute("aria-busy")).toBe("true");
-    expect(fallback?.getAttribute("aria-live")).toBe("polite");
-    expect(fallback?.textContent).toContain("Opening editor");
-    expect(fallback?.textContent).toContain("Preparing your writing workspace.");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const triggerButton = renderer.container.querySelector("button");
+    expect(triggerButton?.textContent).toContain("Trigger toast");
+
+    act(() => {
+      (triggerButton as HTMLButtonElement).click();
+    });
+
+    let toast = renderer.container.querySelector("[role='status']");
+    expect(toast?.getAttribute("data-phase")).toBe("enter");
+
+    act(() => {
+      vi.advanceTimersByTime(3200);
+    });
+
+    toast = renderer.container.querySelector("[role='status']");
+    expect(toast?.getAttribute("data-phase")).toBe("exit");
+
+    act(() => {
+      vi.advanceTimersByTime(180);
+    });
+
+    toast = renderer.container.querySelector("[role='status']");
+    expect(toast).toBeNull();
   });
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -140,8 +140,15 @@ describe("App toast lifecycle", () => {
     toast = renderer.container.querySelector("[role='status']");
     expect(toast?.getAttribute("data-phase")).toBe("exit");
 
+    toast = renderer.container.querySelector("[role='status']");
+    expect(toast?.getAttribute("data-phase")).toBe("exit");
+
     act(() => {
-      vi.advanceTimersByTime(180);
+      const animationEndEvent = new Event("animationend", { bubbles: true });
+      Object.defineProperty(animationEndEvent, "animationName", {
+        value: "ui-toast-exit",
+      });
+      toast?.dispatchEvent(animationEndEvent);
     });
 
     toast = renderer.container.querySelector("[role='status']");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,12 +37,13 @@ import {
   type AppPreferences,
 } from "./lib/preview-preferences";
 import { applyTheme, subscribeToSystemTheme } from "./lib/theme";
-import type { ToastVariant } from "./components/ui/Toast";
+import type { ToastPhase, ToastVariant } from "./components/ui/Toast";
 
 const APP_NAME = "ClipMark";
 const TOAST_DURATION_MS = 3200;
 const TOAST_WARNING_DURATION_MS = 4200;
 const TOAST_ERROR_DURATION_MS = 5600;
+const TOAST_EXIT_DURATION_MS = 180;
 const EditorWorkspace = lazy(() => import("./components/workspace/EditorWorkspace")
   .then((module) => ({ default: module.EditorWorkspace })));
 
@@ -91,26 +92,65 @@ export default function App({ initialPreferences }: AppProps) {
   const [isWindowVisible, setIsWindowVisible] = useState(true);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
   const [toast, setToast] = useState<{
+    id: number;
     message: string;
+    phase: ToastPhase;
     title?: string;
     variant: ToastVariant;
   } | null>(null);
   const editorRef = useRef<MarkdownEditorHandle | null>(null);
   const toastTimeoutRef = useRef<number | null>(null);
+  const toastExitTimeoutRef = useRef<number | null>(null);
+  const toastIdRef = useRef(0);
+
+  const clearToastTimers = useEffectEvent(() => {
+    if (toastTimeoutRef.current !== null) {
+      window.clearTimeout(toastTimeoutRef.current);
+      toastTimeoutRef.current = null;
+    }
+
+    if (toastExitTimeoutRef.current !== null) {
+      window.clearTimeout(toastExitTimeoutRef.current);
+      toastExitTimeoutRef.current = null;
+    }
+  });
+
+  const beginToastExit = useEffectEvent(() => {
+    setToast((currentToast) => {
+      if (!currentToast || currentToast.phase === "exit") {
+        return currentToast;
+      }
+
+      return {
+        ...currentToast,
+        phase: "exit",
+      };
+    });
+
+    toastExitTimeoutRef.current = window.setTimeout(() => {
+      setToast((currentToast) => (currentToast?.phase === "exit" ? null : currentToast));
+      toastExitTimeoutRef.current = null;
+    }, TOAST_EXIT_DURATION_MS);
+  });
 
   const showToast = useEffectEvent((
     message: string,
     variant: ToastVariant = "info",
     title?: string,
   ) => {
-    if (toastTimeoutRef.current !== null) {
-      window.clearTimeout(toastTimeoutRef.current);
-    }
+    clearToastTimers();
+    toastIdRef.current += 1;
 
-    setToast({ message, title, variant });
+    setToast({
+      id: toastIdRef.current,
+      message,
+      phase: "enter",
+      title,
+      variant,
+    });
     toastTimeoutRef.current = window.setTimeout(() => {
-      setToast(null);
       toastTimeoutRef.current = null;
+      beginToastExit();
     }, getToastDuration(variant));
   });
 
@@ -150,6 +190,10 @@ export default function App({ initialPreferences }: AppProps) {
     return () => {
       if (toastTimeoutRef.current !== null) {
         window.clearTimeout(toastTimeoutRef.current);
+      }
+
+      if (toastExitTimeoutRef.current !== null) {
+        window.clearTimeout(toastExitTimeoutRef.current);
       }
     };
   }, []);
@@ -587,7 +631,9 @@ export default function App({ initialPreferences }: AppProps) {
 
       {toast ? (
         <Toast
+          key={toast.id}
           message={toast.message}
+          phase={toast.phase}
           title={toast.title}
           variant={toast.variant}
         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,6 @@ const APP_NAME = "ClipMark";
 const TOAST_DURATION_MS = 3200;
 const TOAST_WARNING_DURATION_MS = 4200;
 const TOAST_ERROR_DURATION_MS = 5600;
-const TOAST_EXIT_DURATION_MS = 180;
 const EditorWorkspace = lazy(() => import("./components/workspace/EditorWorkspace")
   .then((module) => ({ default: module.EditorWorkspace })));
 
@@ -60,6 +59,14 @@ function getToastDuration(variant: ToastVariant) {
     default:
       return TOAST_DURATION_MS;
   }
+}
+
+function prefersReducedToastMotion() {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
 export function AppShellFallback() {
@@ -100,7 +107,6 @@ export default function App({ initialPreferences }: AppProps) {
   } | null>(null);
   const editorRef = useRef<MarkdownEditorHandle | null>(null);
   const toastTimeoutRef = useRef<number | null>(null);
-  const toastExitTimeoutRef = useRef<number | null>(null);
   const toastIdRef = useRef(0);
 
   const clearToastTimers = useEffectEvent(() => {
@@ -108,14 +114,14 @@ export default function App({ initialPreferences }: AppProps) {
       window.clearTimeout(toastTimeoutRef.current);
       toastTimeoutRef.current = null;
     }
-
-    if (toastExitTimeoutRef.current !== null) {
-      window.clearTimeout(toastExitTimeoutRef.current);
-      toastExitTimeoutRef.current = null;
-    }
   });
 
   const beginToastExit = useEffectEvent(() => {
+    if (prefersReducedToastMotion()) {
+      setToast(null);
+      return;
+    }
+
     setToast((currentToast) => {
       if (!currentToast || currentToast.phase === "exit") {
         return currentToast;
@@ -126,11 +132,6 @@ export default function App({ initialPreferences }: AppProps) {
         phase: "exit",
       };
     });
-
-    toastExitTimeoutRef.current = window.setTimeout(() => {
-      setToast((currentToast) => (currentToast?.phase === "exit" ? null : currentToast));
-      toastExitTimeoutRef.current = null;
-    }, TOAST_EXIT_DURATION_MS);
   });
 
   const showToast = useEffectEvent((
@@ -190,10 +191,6 @@ export default function App({ initialPreferences }: AppProps) {
     return () => {
       if (toastTimeoutRef.current !== null) {
         window.clearTimeout(toastTimeoutRef.current);
-      }
-
-      if (toastExitTimeoutRef.current !== null) {
-        window.clearTimeout(toastExitTimeoutRef.current);
       }
     };
   }, []);
@@ -633,6 +630,13 @@ export default function App({ initialPreferences }: AppProps) {
         <Toast
           key={toast.id}
           message={toast.message}
+          onExitComplete={() => {
+            setToast((currentToast) => (
+              currentToast?.id === toast.id && currentToast.phase === "exit"
+                ? null
+                : currentToast
+            ));
+          }}
           phase={toast.phase}
           title={toast.title}
           variant={toast.variant}

--- a/src/components/ui/Toast.test.tsx
+++ b/src/components/ui/Toast.test.tsx
@@ -41,6 +41,7 @@ describe("Toast", () => {
 
     const toast = renderer.container.querySelector("[role='status']");
     expect(toast?.getAttribute("data-variant")).toBe("info");
+    expect(toast?.getAttribute("data-phase")).toBe("enter");
     expect(toast?.getAttribute("aria-live")).toBe("polite");
     expect(toast?.textContent).toContain("Saved.");
     expect(toast?.textContent).toContain("Note");
@@ -74,5 +75,16 @@ describe("Toast", () => {
     expect(toast?.getAttribute("data-variant")).toBe("warning");
     expect(toast?.textContent).toContain("Review recommended");
     expect(toast?.textContent).toContain("Check the imported markdown before saving.");
+  });
+
+  it("renders the exit phase when closing", () => {
+    const renderer = createTestRenderer();
+    cleanupHandlers.push(() => renderer.cleanup());
+
+    renderer.render(<Toast message="Saved." phase="exit" variant="success" />);
+
+    const toast = renderer.container.querySelector("[role='status']");
+    expect(toast?.getAttribute("data-phase")).toBe("exit");
+    expect(toast?.getAttribute("data-variant")).toBe("success");
   });
 });

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,7 +1,9 @@
 export type ToastVariant = "error" | "info" | "success" | "warning";
+export type ToastPhase = "enter" | "exit";
 
 type ToastProps = {
   message: string;
+  phase?: ToastPhase;
   title?: string;
   variant?: ToastVariant;
 };
@@ -40,6 +42,7 @@ const TOAST_META: Record<ToastVariant, {
 
 export function Toast({
   message,
+  phase = "enter",
   title,
   variant = "info",
 }: ToastProps) {
@@ -50,6 +53,7 @@ export function Toast({
       aria-atomic="true"
       aria-live={meta.live}
       className="ui-toast"
+      data-phase={phase}
       data-variant={variant}
       role={meta.role}
     >

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,8 +1,11 @@
+import type { AnimationEventHandler } from "react";
+
 export type ToastVariant = "error" | "info" | "success" | "warning";
 export type ToastPhase = "enter" | "exit";
 
 type ToastProps = {
   message: string;
+  onExitComplete?: () => void;
   phase?: ToastPhase;
   title?: string;
   variant?: ToastVariant;
@@ -42,11 +45,21 @@ const TOAST_META: Record<ToastVariant, {
 
 export function Toast({
   message,
+  onExitComplete,
   phase = "enter",
   title,
   variant = "info",
 }: ToastProps) {
   const meta = TOAST_META[variant];
+  const handleAnimationEnd: AnimationEventHandler<HTMLDivElement> = (event) => {
+    if (
+      phase === "exit"
+      && event.target === event.currentTarget
+      && event.animationName === "ui-toast-exit"
+    ) {
+      onExitComplete?.();
+    }
+  };
 
   return (
     <div
@@ -55,6 +68,7 @@ export function Toast({
       className="ui-toast"
       data-phase={phase}
       data-variant={variant}
+      onAnimationEnd={handleAnimationEnd}
       role={meta.role}
     >
       <div aria-hidden="true" className="ui-toast__icon">

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -137,6 +137,10 @@
   --toast-icon-color: var(--color-toast-info-icon-color);
   --toast-title-color: var(--color-toast-info-title);
   --toast-message-color: var(--color-toast-info-message);
+  --toast-enter-duration: 320ms;
+  --toast-exit-duration: 220ms;
+  --toast-enter-ease: cubic-bezier(0.18, 0.88, 0.24, 1);
+  --toast-exit-ease: cubic-bezier(0.32, 0.02, 0.16, 1);
   position: fixed;
   right: var(--space-5);
   bottom: var(--space-5);
@@ -153,7 +157,15 @@
   box-shadow: var(--shadow-floating);
   color: var(--color-text-strong);
   backdrop-filter: blur(16px);
-  animation: ui-toast-enter var(--duration-base) var(--ease-standard);
+}
+
+.ui-toast[data-phase="enter"] {
+  animation: ui-toast-enter var(--toast-enter-duration) var(--toast-enter-ease);
+}
+
+.ui-toast[data-phase="exit"] {
+  animation: ui-toast-exit var(--toast-exit-duration) var(--toast-exit-ease) forwards;
+  pointer-events: none;
 }
 
 .ui-toast__icon {
@@ -232,6 +244,18 @@
   to {
     opacity: 1;
     transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@keyframes ui-toast-exit {
+  from {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: translate3d(0, 0.35rem, 0) scale(0.985);
   }
 }
 


### PR DESCRIPTION
## 배경
토스트에 퇴장 애니메이션을 추가했지만, 초기 구현은 JS 타이머와 CSS 애니메이션 시간이 분리되어 있어 언마운트 시점이 어긋날 수 있었습니다. 또한 실제 사용감 측면에서 enter/exit 모션이 다소 빠르게 느껴졌습니다.

## 변경 사항
- 토스트에 `phase` 기반 lifecycle을 도입해 enter/exit 상태를 명시적으로 표현했습니다.
- 자동 만료 시에는 바로 언마운트하지 않고 `exit` phase로 전환한 뒤, 실제 `animationend` 시점에만 컴포넌트를 제거하도록 변경했습니다.
- 토스트 enter/exit 애니메이션의 시간과 easing을 더 부드럽게 조정했습니다.
- 토스트 lifecycle 회귀를 막기 위해 `App` 테스트를 추가하고, `animationend` 기반으로 `enter -> exit -> unmount` 흐름을 검증했습니다.

## 영향
- 토스트가 CSS 애니메이션 완료 전에 잘려서 사라지지 않고, 실제 퇴장 완료 시점까지 자연스럽게 유지됩니다.
- 모션이 이전보다 덜 급하게 느껴지고, 자동 닫힘 동작의 일관성이 좋아집니다.
- 현재 브랜치에는 검토를 위해 사용했던 임시 히어로 테스트 UI는 포함되지 않습니다.

## 검증
- `npm run test -- App Toast`
- `npm run build`

## 커밋
- `feat(toast): 퇴장 애니메이션과 모션 검토 UI 추가`
- `fix(toast): 애니메이션 완료 시점에 언마운트`