### PR TITLE
fix(preview): 미리보기 자동 스크롤 안정화

### DIFF
--- a/docs/superpowers/plans/2026-05-22-preview-auto-scroll.md
+++ b/docs/superpowers/plans/2026-05-22-preview-auto-scroll.md
@@ -1,0 +1,918 @@
+# Preview Auto Scroll Stabilization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 편집 중 활성 줄 기반 미리보기 자동 스크롤을 anchor 블록 단위로 안정화해 입력 중 흔들림을 줄인다.
+
+**Architecture:** `preview-scroll`에는 anchor key와 탐색 관련 순수 로직을 두고, `MarkdownPreview`는 DOM 측정, animation frame 예약, 수동 스크롤 suspend 상태만 관리한다. 자동 스크롤의 주 트리거는 `activeLine` 변경으로 제한하고, `previewHtml` 변경은 anchor 목록 갱신만 담당한다.
+
+**Tech Stack:** React 19, TypeScript, Vitest, jsdom, Vite
+
+---
+
+## File Structure
+
+- Modify: `src/lib/preview-scroll.ts`
+  - preview anchor key를 생성하는 helper를 추가한다.
+- Modify: `src/lib/preview-scroll.test.ts`
+  - anchor key와 기존 closest anchor 동작을 검증한다.
+- Modify: `src/components/preview/MarkdownPreview.tsx`
+  - `lastSyncedLineRef`를 anchor key 기반 상태로 교체한다.
+  - preview HTML 변경 시 즉시 스크롤하지 않도록 effect 책임을 분리한다.
+  - 자동 스크롤을 `requestAnimationFrame`으로 예약하고 입력 중 `behavior: "auto"`를 사용한다.
+  - 수동 preview 스크롤 감지 후 자동 추적을 잠시 중단한다.
+- Modify: `src/components/preview/MarkdownPreview.test.tsx`
+  - 재렌더, 같은 anchor 내부 이동, 다른 anchor 이동, 수동 스크롤 suspend, behavior 정책을 검증한다.
+
+### Task 1: Preview anchor key helper 추가
+
+**Files:**
+- Modify: `src/lib/preview-scroll.ts`
+- Modify: `src/lib/preview-scroll.test.ts`
+
+- [x] **Step 1: helper 테스트를 먼저 추가한다**
+
+`src/lib/preview-scroll.test.ts`의 import를 확장하고 다음 테스트를 추가한다.
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  findClosestPreviewAnchor,
+  getPreviewAnchorKey,
+} from "./preview-scroll";
+
+describe("getPreviewAnchorKey", () => {
+  it("returns a stable key for an anchor range", () => {
+    expect(getPreviewAnchorKey({ lineStart: 12, lineEnd: 16 })).toBe("12:16");
+  });
+});
+```
+
+- [x] **Step 2: 테스트 실패를 확인한다**
+
+Run: `npm run test -- src/lib/preview-scroll.test.ts`
+
+Expected: FAIL with `Module '"./preview-scroll"' has no exported member 'getPreviewAnchorKey'`.
+
+- [x] **Step 3: 최소 구현을 추가한다**
+
+`src/lib/preview-scroll.ts`에 helper를 추가한다.
+
+```ts
+export function getPreviewAnchorKey(anchor: PreviewScrollAnchor) {
+  return `${anchor.lineStart}:${anchor.lineEnd}`;
+}
+```
+
+- [x] **Step 4: 테스트 통과를 확인한다**
+
+Run: `npm run test -- src/lib/preview-scroll.test.ts`
+
+Expected: PASS.
+
+- [x] **Step 5: 변경을 커밋한다**
+
+```bash
+git add src/lib/preview-scroll.ts src/lib/preview-scroll.test.ts
+git commit -m "refactor(preview): add stable preview anchor keys"
+```
+
+### Task 2: MarkdownPreview 자동 스크롤 트리거 분리
+
+**Files:**
+- Modify: `src/components/preview/MarkdownPreview.tsx`
+- Modify: `src/components/preview/MarkdownPreview.test.tsx`
+
+- [ ] **Step 1: preview HTML 재렌더만으로 스크롤하지 않는 실패 테스트를 추가한다**
+
+`src/components/preview/MarkdownPreview.test.tsx`에 다음 테스트를 추가한다.
+
+```tsx
+it("does not scroll again when only the preview html changes for the same active anchor", () => {
+  const renderer = createTestRenderer();
+  cleanupHandlers.push(() => renderer.cleanup());
+
+  const originalScrollTo = HTMLElement.prototype.scrollTo;
+  const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+    this.scrollTop = options.top ?? 0;
+  });
+  Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+    configurable: true,
+    value: scrollTo,
+    writable: true,
+  });
+  cleanupHandlers.push(() => {
+    if (originalScrollTo) {
+      Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+        configurable: true,
+        value: originalScrollTo,
+        writable: true,
+      });
+      return;
+    }
+
+    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+  });
+
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+    return this.classList.contains("markdown-preview") ? 400 : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+    return this.classList.contains("markdown-preview") ? 1200 : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+    if (this.classList.contains("markdown-preview")) {
+      return new DOMRect(0, 0, 320, 400);
+    }
+
+    const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
+    if (lineStart === 5) {
+      return new DOMRect(0, 520, 320, 48);
+    }
+
+    return new DOMRect(0, 0, 0, 0);
+  });
+
+  renderer.render({
+    activeLine: 5,
+    markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+  });
+  const initialCallCount = scrollTo.mock.calls.length;
+
+  renderer.render({
+    activeLine: 5,
+    markdown: "# Heading\n\nFirst paragraph\n\n## Section updated\n\nSecond paragraph",
+  });
+
+  expect(scrollTo).toHaveBeenCalledTimes(initialCallCount);
+});
+```
+
+- [ ] **Step 2: 테스트 실패를 확인한다**
+
+Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
+
+Expected: FAIL because `scrollTo` is called again after `previewHtml` changes.
+
+- [ ] **Step 3: `MarkdownPreview`에서 previewHtml effect의 스크롤 호출을 제거한다**
+
+`src/components/preview/MarkdownPreview.tsx`의 import와 refs를 먼저 바꾼다.
+
+```tsx
+import {
+  findClosestPreviewAnchor,
+  getPreviewAnchorKey,
+  type PreviewScrollAnchor,
+} from "../../lib/preview-scroll";
+```
+
+```tsx
+const lastSyncedAnchorKeyRef = useRef<string | null>(null);
+```
+
+기존 `lastSyncedLineRef` 사용을 제거하고, `previewHtml` effect는 anchor 목록만 갱신하게 만든다.
+
+```tsx
+useEffect(() => {
+  const container = rootRef.current;
+  if (!container) {
+    anchorsRef.current = [];
+    return;
+  }
+
+  anchorsRef.current = Array.from(
+    container.querySelectorAll<HTMLElement>("[data-source-line-start]"),
+  )
+    .map((element) => {
+      const lineStart = Number(element.dataset.sourceLineStart);
+      const lineEnd = Number(element.dataset.sourceLineEnd ?? lineStart);
+
+      if (!Number.isFinite(lineStart) || !Number.isFinite(lineEnd)) {
+        return null;
+      }
+
+      return {
+        element,
+        lineEnd,
+        lineStart,
+      };
+    })
+    .filter((anchor): anchor is PreviewAnchorElement => anchor !== null);
+}, [previewHtml]);
+```
+
+- [ ] **Step 4: activeLine effect에서만 스크롤을 실행하도록 조정한다**
+
+`syncPreviewScroll` 내부의 중복 방지 조건을 anchor key 기준으로 바꾼다.
+
+```tsx
+const targetAnchor = findClosestPreviewAnchor(anchorsRef.current, activeLine);
+if (!targetAnchor) {
+  return;
+}
+
+const targetAnchorKey = getPreviewAnchorKey(targetAnchor);
+if (lastSyncedAnchorKeyRef.current === targetAnchorKey) {
+  return;
+}
+```
+
+스크롤하지 않아도 현재 anchor가 안정 영역에 있으면 key를 기록한다.
+
+```tsx
+if (
+  targetRect.top >= visibleTopThreshold &&
+  targetRect.top <= visibleBottomThreshold
+) {
+  lastSyncedAnchorKeyRef.current = targetAnchorKey;
+  return;
+}
+```
+
+스크롤 후에도 같은 key를 기록한다.
+
+```tsx
+scrollPreviewTo(container, nextScrollTop, "auto");
+lastSyncedAnchorKeyRef.current = targetAnchorKey;
+```
+
+- [ ] **Step 5: 테스트 통과를 확인한다**
+
+Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
+
+Expected: PASS for the new preview HTML rerender test, with any old layoutVersion expectation updated in Task 4.
+
+- [ ] **Step 6: 변경을 커밋한다**
+
+```bash
+git add src/components/preview/MarkdownPreview.tsx src/components/preview/MarkdownPreview.test.tsx
+git commit -m "fix(preview): avoid scrolling on preview rerender"
+```
+
+### Task 3: 같은 anchor 내부 이동은 스크롤하지 않고 다른 anchor 이동은 스크롤한다
+
+**Files:**
+- Modify: `src/components/preview/MarkdownPreview.tsx`
+- Modify: `src/components/preview/MarkdownPreview.test.tsx`
+
+- [ ] **Step 1: 같은 anchor 내부 activeLine 변경 테스트를 추가한다**
+
+`src/components/preview/MarkdownPreview.test.tsx`에 다음 테스트를 추가한다.
+
+```tsx
+it("does not scroll while the active line stays inside the same preview anchor", () => {
+  const renderer = createTestRenderer();
+  cleanupHandlers.push(() => renderer.cleanup());
+
+  const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+    this.scrollTop = options.top ?? 0;
+  });
+  const originalScrollTo = HTMLElement.prototype.scrollTo;
+  Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+    configurable: true,
+    value: scrollTo,
+    writable: true,
+  });
+  cleanupHandlers.push(() => {
+    if (originalScrollTo) {
+      Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+        configurable: true,
+        value: originalScrollTo,
+        writable: true,
+      });
+      return;
+    }
+
+    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+  });
+
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+    return this.classList.contains("markdown-preview") ? 400 : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+    return this.classList.contains("markdown-preview") ? 1200 : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+    if (this.classList.contains("markdown-preview")) {
+      return new DOMRect(0, 0, 320, 400);
+    }
+
+    if (this.dataset.sourceLineStart === "1") {
+      return new DOMRect(0, 520, 320, 120);
+    }
+
+    return new DOMRect(0, 0, 0, 0);
+  });
+
+  renderer.render({
+    activeLine: 1,
+    markdown: "First line\nSecond line\nThird line",
+  });
+  const initialCallCount = scrollTo.mock.calls.length;
+
+  renderer.render({
+    activeLine: 2,
+    markdown: "First line\nSecond line\nThird line",
+  });
+
+  expect(scrollTo).toHaveBeenCalledTimes(initialCallCount);
+});
+```
+
+- [ ] **Step 2: 다른 anchor 이동 테스트를 보강한다**
+
+기존 `"scrolls the preview when the active line changes to an off-screen block"` 테스트의 기대값을 `behavior: "auto"`로 바꾼다.
+
+```tsx
+expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({
+  behavior: "auto",
+}));
+```
+
+- [ ] **Step 3: 테스트 실패를 확인한다**
+
+Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
+
+Expected: FAIL if same-anchor line changes still call `scrollTo`, or if behavior is still `smooth`.
+
+- [ ] **Step 4: `scrollPreviewTo`가 behavior를 인자로 받게 바꾼다**
+
+`src/components/preview/MarkdownPreview.tsx`의 helper를 다음 형태로 바꾼다.
+
+```tsx
+type PreviewScrollBehavior = ScrollBehavior;
+
+function scrollPreviewTo(
+  container: HTMLDivElement,
+  top: number,
+  behavior: PreviewScrollBehavior,
+) {
+  const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  if (typeof container.scrollTo === "function") {
+    container.scrollTo({
+      behavior: prefersReducedMotion ? "auto" : behavior,
+      top,
+    });
+    return;
+  }
+
+  container.scrollTop = top;
+}
+```
+
+자동 추적 호출은 `auto`를 넘긴다.
+
+```tsx
+scrollPreviewTo(container, nextScrollTop, "auto");
+```
+
+- [ ] **Step 5: 테스트 통과를 확인한다**
+
+Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 6: 변경을 커밋한다**
+
+```bash
+git add src/components/preview/MarkdownPreview.tsx src/components/preview/MarkdownPreview.test.tsx
+git commit -m "fix(preview): sync scroll by anchor block"
+```
+
+### Task 4: requestAnimationFrame 예약과 layoutVersion 기대값 정리
+
+**Files:**
+- Modify: `src/components/preview/MarkdownPreview.tsx`
+- Modify: `src/components/preview/MarkdownPreview.test.tsx`
+
+- [ ] **Step 1: `requestAnimationFrame` 기반 동기화 테스트를 준비한다**
+
+`src/components/preview/MarkdownPreview.test.tsx`의 `afterEach`에 fake timer cleanup이 없다면 각 테스트 안에서 `vi.useFakeTimers()`와 `vi.useRealTimers()`를 사용한다. 새 테스트는 다음 형태로 추가한다.
+
+```tsx
+it("coalesces rapid active line changes into the latest scheduled scroll", () => {
+  vi.useFakeTimers();
+  cleanupHandlers.push(() => vi.useRealTimers());
+
+  const requestAnimationFrameSpy = vi
+    .spyOn(window, "requestAnimationFrame")
+    .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+  const cancelAnimationFrameSpy = vi
+    .spyOn(window, "cancelAnimationFrame")
+    .mockImplementation((handle) => window.clearTimeout(handle));
+  cleanupHandlers.push(() => {
+    requestAnimationFrameSpy.mockRestore();
+    cancelAnimationFrameSpy.mockRestore();
+  });
+
+  const renderer = createTestRenderer();
+  cleanupHandlers.push(() => renderer.cleanup());
+
+  const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+    this.scrollTop = options.top ?? 0;
+  });
+  const originalScrollTo = HTMLElement.prototype.scrollTo;
+  Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+    configurable: true,
+    value: scrollTo,
+    writable: true,
+  });
+  cleanupHandlers.push(() => {
+    if (originalScrollTo) {
+      Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+        configurable: true,
+        value: originalScrollTo,
+        writable: true,
+      });
+      return;
+    }
+
+    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+  });
+
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+    return this.classList.contains("markdown-preview") ? 400 : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+    return this.classList.contains("markdown-preview") ? 1400 : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+    if (this.classList.contains("markdown-preview")) {
+      return new DOMRect(0, 0, 320, 400);
+    }
+
+    const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
+    if (lineStart === 5) {
+      return new DOMRect(0, 520, 320, 48);
+    }
+    if (lineStart === 7) {
+      return new DOMRect(0, 760, 320, 48);
+    }
+
+    return new DOMRect(0, 0, 0, 0);
+  });
+
+  renderer.render({
+    activeLine: 5,
+    markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+  });
+  renderer.render({
+    activeLine: 7,
+    markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+  });
+
+  expect(cancelAnimationFrameSpy).toHaveBeenCalled();
+
+  act(() => {
+    vi.advanceTimersByTime(16);
+  });
+
+  expect(scrollTo).toHaveBeenCalledTimes(1);
+});
+```
+
+- [ ] **Step 2: 기존 layoutVersion 테스트를 새 정책에 맞게 바꾼다**
+
+기존 `"re-syncs preview scrolling when the layout version changes"` 테스트는 삭제하거나 다음 기대값으로 바꾼다.
+
+```tsx
+it("does not scroll solely because the layout version changes", () => {
+  const renderer = createTestRenderer();
+  cleanupHandlers.push(() => renderer.cleanup());
+
+  const scrollTo = vi.fn();
+  const originalScrollTo = HTMLElement.prototype.scrollTo;
+  Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+    configurable: true,
+    value: scrollTo,
+    writable: true,
+  });
+  cleanupHandlers.push(() => {
+    if (originalScrollTo) {
+      Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+        configurable: true,
+        value: originalScrollTo,
+        writable: true,
+      });
+      return;
+    }
+
+    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+  });
+
+  renderer.render({
+    activeLine: 5,
+    layoutVersion: 0,
+    markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+  });
+  const initialCallCount = scrollTo.mock.calls.length;
+
+  renderer.render({
+    activeLine: 5,
+    layoutVersion: 1,
+    markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+  });
+
+  expect(scrollTo).toHaveBeenCalledTimes(initialCallCount);
+});
+```
+
+- [ ] **Step 3: 테스트 실패를 확인한다**
+
+Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
+
+Expected: FAIL because sync is still immediate or layoutVersion still resets and scrolls.
+
+- [ ] **Step 4: pending animation frame ref와 예약 함수를 추가한다**
+
+`src/components/preview/MarkdownPreview.tsx`에 ref와 cleanup을 추가한다.
+
+```tsx
+const pendingScrollFrameRef = useRef<number | null>(null);
+
+const cancelPendingPreviewScroll = useEffectEvent(() => {
+  if (pendingScrollFrameRef.current === null) {
+    return;
+  }
+
+  window.cancelAnimationFrame(pendingScrollFrameRef.current);
+  pendingScrollFrameRef.current = null;
+});
+```
+
+예약 함수를 추가한다.
+
+```tsx
+const schedulePreviewScroll = useEffectEvent(() => {
+  cancelPendingPreviewScroll();
+  pendingScrollFrameRef.current = window.requestAnimationFrame(() => {
+    pendingScrollFrameRef.current = null;
+    syncPreviewScroll();
+  });
+});
+```
+
+activeLine effect는 즉시 호출 대신 예약한다.
+
+```tsx
+useEffect(() => {
+  schedulePreviewScroll();
+}, [activeLine, isAutoScrollEnabled, isLayoutTransitioning, schedulePreviewScroll]);
+```
+
+layoutVersion effect와 ResizeObserver에서 `lastSyncedAnchorKeyRef`를 초기화하고 `syncPreviewScroll()`을 호출하던 코드는 제거한다. unmount cleanup은 pending frame만 취소한다.
+
+```tsx
+useEffect(() => {
+  return () => {
+    cancelPendingPreviewScroll();
+  };
+}, [cancelPendingPreviewScroll]);
+```
+
+- [ ] **Step 5: 테스트 통과를 확인한다**
+
+Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 6: 변경을 커밋한다**
+
+```bash
+git add src/components/preview/MarkdownPreview.tsx src/components/preview/MarkdownPreview.test.tsx
+git commit -m "fix(preview): schedule preview scroll once per frame"
+```
+
+### Task 5: 수동 미리보기 스크롤을 존중한다
+
+**Files:**
+- Modify: `src/components/preview/MarkdownPreview.tsx`
+- Modify: `src/components/preview/MarkdownPreview.test.tsx`
+
+- [ ] **Step 1: 수동 스크롤 suspend 테스트를 추가한다**
+
+`src/components/preview/MarkdownPreview.test.tsx`에 다음 테스트를 추가한다.
+
+```tsx
+it("temporarily suspends auto-scroll after the user scrolls the preview", () => {
+  vi.useFakeTimers();
+  cleanupHandlers.push(() => vi.useRealTimers());
+
+  const requestAnimationFrameSpy = vi
+    .spyOn(window, "requestAnimationFrame")
+    .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+  const cancelAnimationFrameSpy = vi
+    .spyOn(window, "cancelAnimationFrame")
+    .mockImplementation((handle) => window.clearTimeout(handle));
+  cleanupHandlers.push(() => {
+    requestAnimationFrameSpy.mockRestore();
+    cancelAnimationFrameSpy.mockRestore();
+  });
+
+  const renderer = createTestRenderer();
+  cleanupHandlers.push(() => renderer.cleanup());
+
+  const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+    this.scrollTop = options.top ?? 0;
+    this.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+  const originalScrollTo = HTMLElement.prototype.scrollTo;
+  Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+    configurable: true,
+    value: scrollTo,
+    writable: true,
+  });
+  cleanupHandlers.push(() => {
+    if (originalScrollTo) {
+      Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+        configurable: true,
+        value: originalScrollTo,
+        writable: true,
+      });
+      return;
+    }
+
+    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+  });
+
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+    return this.classList.contains("markdown-preview") ? 400 : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+    return this.classList.contains("markdown-preview") ? 1400 : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+    if (this.classList.contains("markdown-preview")) {
+      return new DOMRect(0, 0, 320, 400);
+    }
+
+    const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
+    if (lineStart === 5) {
+      return new DOMRect(0, 520, 320, 48);
+    }
+    if (lineStart === 7) {
+      return new DOMRect(0, 760, 320, 48);
+    }
+
+    return new DOMRect(0, 0, 0, 0);
+  });
+
+  renderer.render({
+    activeLine: 5,
+    markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+  });
+
+  act(() => {
+    vi.advanceTimersByTime(16);
+  });
+
+  const previewElement = renderer.container.querySelector(".markdown-preview") as HTMLDivElement;
+  act(() => {
+    previewElement.dispatchEvent(new WheelEvent("wheel", { bubbles: true }));
+    previewElement.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+
+  const callCountAfterManualScroll = scrollTo.mock.calls.length;
+
+  renderer.render({
+    activeLine: 7,
+    markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+  });
+
+  act(() => {
+    vi.advanceTimersByTime(16);
+  });
+
+  expect(scrollTo).toHaveBeenCalledTimes(callCountAfterManualScroll);
+});
+```
+
+- [ ] **Step 2: 테스트 실패를 확인한다**
+
+Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
+
+Expected: FAIL because auto-scroll still runs after manual preview scroll.
+
+- [ ] **Step 3: 수동 스크롤 suspend 상태를 추가한다**
+
+`src/components/preview/MarkdownPreview.tsx`에 상수와 refs를 추가한다.
+
+```tsx
+const MANUAL_SCROLL_SUSPEND_MS = 900;
+```
+
+```tsx
+const isProgrammaticScrollRef = useRef(false);
+const manualScrollSuspendUntilRef = useRef(0);
+```
+
+`scrollPreviewTo` 호출 전후로 programmatic scroll 표시를 설정한다.
+
+```tsx
+isProgrammaticScrollRef.current = true;
+scrollPreviewTo(container, nextScrollTop, "auto");
+window.setTimeout(() => {
+  isProgrammaticScrollRef.current = false;
+}, 0);
+lastSyncedAnchorKeyRef.current = targetAnchorKey;
+```
+
+수동 스크롤 여부를 확인하는 helper를 추가한다.
+
+```tsx
+const isManualScrollSuspended = useEffectEvent(() => {
+  return Date.now() < manualScrollSuspendUntilRef.current;
+});
+```
+
+`syncPreviewScroll` 초반에 suspend를 반영한다.
+
+```tsx
+if (isManualScrollSuspended()) {
+  return;
+}
+```
+
+preview root에 wheel과 scroll handler를 추가한다.
+
+```tsx
+onWheel={() => {
+  manualScrollSuspendUntilRef.current = Date.now() + MANUAL_SCROLL_SUSPEND_MS;
+}}
+onScroll={() => {
+  if (isProgrammaticScrollRef.current) {
+    return;
+  }
+
+  manualScrollSuspendUntilRef.current = Date.now() + MANUAL_SCROLL_SUSPEND_MS;
+}}
+```
+
+- [ ] **Step 4: suspend 만료 후 다시 따라가는 테스트를 추가한다**
+
+같은 파일에 다음 테스트를 추가한다.
+
+```tsx
+it("resumes auto-scroll after the manual scroll suspension expires", () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-05-22T00:00:00.000Z"));
+  cleanupHandlers.push(() => {
+    vi.useRealTimers();
+  });
+
+  const requestAnimationFrameSpy = vi
+    .spyOn(window, "requestAnimationFrame")
+    .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+  const cancelAnimationFrameSpy = vi
+    .spyOn(window, "cancelAnimationFrame")
+    .mockImplementation((handle) => window.clearTimeout(handle));
+  cleanupHandlers.push(() => {
+    requestAnimationFrameSpy.mockRestore();
+    cancelAnimationFrameSpy.mockRestore();
+  });
+
+  const renderer = createTestRenderer();
+  cleanupHandlers.push(() => renderer.cleanup());
+
+  const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+    this.scrollTop = options.top ?? 0;
+  });
+  const originalScrollTo = HTMLElement.prototype.scrollTo;
+  Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+    configurable: true,
+    value: scrollTo,
+    writable: true,
+  });
+  cleanupHandlers.push(() => {
+    if (originalScrollTo) {
+      Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+        configurable: true,
+        value: originalScrollTo,
+        writable: true,
+      });
+      return;
+    }
+
+    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+  });
+
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+    return this.classList.contains("markdown-preview") ? 400 : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+    return this.classList.contains("markdown-preview") ? 1400 : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+    if (this.classList.contains("markdown-preview")) {
+      return new DOMRect(0, 0, 320, 400);
+    }
+
+    const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
+    if (lineStart === 5) {
+      return new DOMRect(0, 520, 320, 48);
+    }
+    if (lineStart === 7) {
+      return new DOMRect(0, 760, 320, 48);
+    }
+
+    return new DOMRect(0, 0, 0, 0);
+  });
+
+  renderer.render({
+    activeLine: 5,
+    markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+  });
+
+  act(() => {
+    vi.advanceTimersByTime(16);
+  });
+
+  const previewElement = renderer.container.querySelector(".markdown-preview") as HTMLDivElement;
+  act(() => {
+    previewElement.dispatchEvent(new WheelEvent("wheel", { bubbles: true }));
+    vi.advanceTimersByTime(901);
+  });
+
+  const callCountBeforeResume = scrollTo.mock.calls.length;
+  renderer.render({
+    activeLine: 7,
+    markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+  });
+
+  act(() => {
+    vi.advanceTimersByTime(16);
+  });
+
+  expect(scrollTo.mock.calls.length).toBeGreaterThan(callCountBeforeResume);
+});
+```
+
+- [ ] **Step 5: 테스트 통과를 확인한다**
+
+Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 6: 변경을 커밋한다**
+
+```bash
+git add src/components/preview/MarkdownPreview.tsx src/components/preview/MarkdownPreview.test.tsx
+git commit -m "fix(preview): respect manual preview scrolling"
+```
+
+### Task 6: 전체 검증과 회귀 확인
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: preview 관련 테스트를 실행한다**
+
+Run: `npm run test -- src/lib/preview-scroll.test.ts src/components/preview/MarkdownPreview.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 2: 전체 테스트를 실행한다**
+
+Run: `npm run test`
+
+Expected: PASS.
+
+- [ ] **Step 3: 빌드를 실행한다**
+
+Run: `npm run build`
+
+Expected: PASS with Vite production bundle generated.
+
+- [ ] **Step 4: 수동 확인을 위한 dev server를 실행한다**
+
+Run: `npm run dev`
+
+Expected: Vite dev server starts on `127.0.0.1:1420`.
+
+- [ ] **Step 5: 수동 QA 시나리오를 확인한다**
+
+브라우저나 Tauri dev 환경에서 다음을 확인한다.
+
+```text
+1. 긴 Markdown 문서를 연다.
+2. 같은 문단 안에서 여러 줄을 계속 타이핑한다.
+3. 미리보기 패널이 반복적으로 위아래로 흔들리지 않는지 본다.
+4. 에디터 커서를 다른 heading 또는 다른 문단으로 이동한다.
+5. 해당 preview anchor가 화면 밖이면 한 번만 따라오는지 본다.
+6. preview 패널을 직접 스크롤한 직후 에디터에서 입력한다.
+7. preview 패널이 즉시 다시 끌려오지 않는지 본다.
+```
+
+- [ ] **Step 6: 남은 수정이 있는 경우만 최종 정리 커밋을 만든다**
+
+```bash
+git status --short
+```
+
+Expected: 이전 task별 커밋을 모두 만들었다면 working tree가 비어 있다. 수동 QA 중 보완한 수정이 남아 있을 때만 다음 명령을 실행한다.
+
+```bash
+git add src/lib/preview-scroll.ts src/lib/preview-scroll.test.ts src/components/preview/MarkdownPreview.tsx src/components/preview/MarkdownPreview.test.tsx
+git commit -m "fix(preview): stabilize active line auto-scroll"
+```

--- a/docs/superpowers/plans/2026-05-22-preview-auto-scroll.md
+++ b/docs/superpowers/plans/2026-05-22-preview-auto-scroll.md
@@ -255,7 +255,7 @@ git commit -m "fix(preview): avoid scrolling on preview rerender"
 - Modify: `src/components/preview/MarkdownPreview.tsx`
 - Modify: `src/components/preview/MarkdownPreview.test.tsx`
 
-- [ ] **Step 1: 같은 anchor 내부 activeLine 변경 테스트를 추가한다**
+- [x] **Step 1: 같은 anchor 내부 activeLine 변경 테스트를 추가한다**
 
 `src/components/preview/MarkdownPreview.test.tsx`에 다음 테스트를 추가한다.
 
@@ -319,7 +319,7 @@ it("does not scroll while the active line stays inside the same preview anchor",
 });
 ```
 
-- [ ] **Step 2: 다른 anchor 이동 테스트를 보강한다**
+- [x] **Step 2: 다른 anchor 이동 테스트를 보강한다**
 
 기존 `"scrolls the preview when the active line changes to an off-screen block"` 테스트의 기대값을 `behavior: "auto"`로 바꾼다.
 
@@ -329,13 +329,13 @@ expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({
 }));
 ```
 
-- [ ] **Step 3: 테스트 실패를 확인한다**
+- [x] **Step 3: 테스트 실패를 확인한다**
 
 Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
 
 Expected: FAIL if same-anchor line changes still call `scrollTo`, or if behavior is still `smooth`.
 
-- [ ] **Step 4: `scrollPreviewTo`가 behavior를 인자로 받게 바꾼다**
+- [x] **Step 4: `scrollPreviewTo`가 behavior를 인자로 받게 바꾼다**
 
 `src/components/preview/MarkdownPreview.tsx`의 helper를 다음 형태로 바꾼다.
 
@@ -367,13 +367,13 @@ function scrollPreviewTo(
 scrollPreviewTo(container, nextScrollTop, "auto");
 ```
 
-- [ ] **Step 5: 테스트 통과를 확인한다**
+- [x] **Step 5: 테스트 통과를 확인한다**
 
 Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
 
 Expected: PASS.
 
-- [ ] **Step 6: 변경을 커밋한다**
+- [x] **Step 6: 변경을 커밋한다**
 
 ```bash
 git add src/components/preview/MarkdownPreview.tsx src/components/preview/MarkdownPreview.test.tsx

--- a/docs/superpowers/plans/2026-05-22-preview-auto-scroll.md
+++ b/docs/superpowers/plans/2026-05-22-preview-auto-scroll.md
@@ -866,31 +866,31 @@ git commit -m "fix(preview): respect manual preview scrolling"
 **Files:**
 - Modify: none
 
-- [ ] **Step 1: preview 관련 테스트를 실행한다**
+- [x] **Step 1: preview 관련 테스트를 실행한다**
 
 Run: `npm run test -- src/lib/preview-scroll.test.ts src/components/preview/MarkdownPreview.test.tsx`
 
 Expected: PASS.
 
-- [ ] **Step 2: 전체 테스트를 실행한다**
+- [x] **Step 2: 전체 테스트를 실행한다**
 
 Run: `npm run test`
 
 Expected: PASS.
 
-- [ ] **Step 3: 빌드를 실행한다**
+- [x] **Step 3: 빌드를 실행한다**
 
 Run: `npm run build`
 
 Expected: PASS with Vite production bundle generated.
 
-- [ ] **Step 4: 수동 확인을 위한 dev server를 실행한다**
+- [x] **Step 4: 수동 확인을 위한 dev server를 실행한다**
 
 Run: `npm run dev`
 
 Expected: Vite dev server starts on `127.0.0.1:1420`.
 
-- [ ] **Step 5: 수동 QA 시나리오를 확인한다**
+- [x] **Step 5: 수동 QA 시나리오를 확인한다**
 
 브라우저나 Tauri dev 환경에서 다음을 확인한다.
 
@@ -904,7 +904,7 @@ Expected: Vite dev server starts on `127.0.0.1:1420`.
 7. preview 패널이 즉시 다시 끌려오지 않는지 본다.
 ```
 
-- [ ] **Step 6: 남은 수정이 있는 경우만 최종 정리 커밋을 만든다**
+- [x] **Step 6: 남은 수정이 있는 경우만 최종 정리 커밋을 만든다**
 
 ```bash
 git status --short

--- a/docs/superpowers/plans/2026-05-22-preview-auto-scroll.md
+++ b/docs/superpowers/plans/2026-05-22-preview-auto-scroll.md
@@ -83,7 +83,7 @@ git commit -m "refactor(preview): add stable preview anchor keys"
 - Modify: `src/components/preview/MarkdownPreview.tsx`
 - Modify: `src/components/preview/MarkdownPreview.test.tsx`
 
-- [ ] **Step 1: preview HTML 재렌더만으로 스크롤하지 않는 실패 테스트를 추가한다**
+- [x] **Step 1: preview HTML 재렌더만으로 스크롤하지 않는 실패 테스트를 추가한다**
 
 `src/components/preview/MarkdownPreview.test.tsx`에 다음 테스트를 추가한다.
 
@@ -148,13 +148,13 @@ it("does not scroll again when only the preview html changes for the same active
 });
 ```
 
-- [ ] **Step 2: 테스트 실패를 확인한다**
+- [x] **Step 2: 테스트 실패를 확인한다**
 
 Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
 
 Expected: FAIL because `scrollTo` is called again after `previewHtml` changes.
 
-- [ ] **Step 3: `MarkdownPreview`에서 previewHtml effect의 스크롤 호출을 제거한다**
+- [x] **Step 3: `MarkdownPreview`에서 previewHtml effect의 스크롤 호출을 제거한다**
 
 `src/components/preview/MarkdownPreview.tsx`의 import와 refs를 먼저 바꾼다.
 
@@ -201,7 +201,7 @@ useEffect(() => {
 }, [previewHtml]);
 ```
 
-- [ ] **Step 4: activeLine effect에서만 스크롤을 실행하도록 조정한다**
+- [x] **Step 4: activeLine effect에서만 스크롤을 실행하도록 조정한다**
 
 `syncPreviewScroll` 내부의 중복 방지 조건을 anchor key 기준으로 바꾼다.
 
@@ -236,13 +236,13 @@ scrollPreviewTo(container, nextScrollTop, "auto");
 lastSyncedAnchorKeyRef.current = targetAnchorKey;
 ```
 
-- [ ] **Step 5: 테스트 통과를 확인한다**
+- [x] **Step 5: 테스트 통과를 확인한다**
 
 Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
 
 Expected: PASS for the new preview HTML rerender test, with any old layoutVersion expectation updated in Task 4.
 
-- [ ] **Step 6: 변경을 커밋한다**
+- [x] **Step 6: 변경을 커밋한다**
 
 ```bash
 git add src/components/preview/MarkdownPreview.tsx src/components/preview/MarkdownPreview.test.tsx

--- a/docs/superpowers/plans/2026-05-22-preview-auto-scroll.md
+++ b/docs/superpowers/plans/2026-05-22-preview-auto-scroll.md
@@ -590,7 +590,7 @@ git commit -m "fix(preview): schedule preview scroll once per frame"
 - Modify: `src/components/preview/MarkdownPreview.tsx`
 - Modify: `src/components/preview/MarkdownPreview.test.tsx`
 
-- [ ] **Step 1: 수동 스크롤 suspend 테스트를 추가한다**
+- [x] **Step 1: 수동 스크롤 suspend 테스트를 추가한다**
 
 `src/components/preview/MarkdownPreview.test.tsx`에 다음 테스트를 추가한다.
 
@@ -688,13 +688,13 @@ it("temporarily suspends auto-scroll after the user scrolls the preview", () => 
 });
 ```
 
-- [ ] **Step 2: 테스트 실패를 확인한다**
+- [x] **Step 2: 테스트 실패를 확인한다**
 
 Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
 
 Expected: FAIL because auto-scroll still runs after manual preview scroll.
 
-- [ ] **Step 3: 수동 스크롤 suspend 상태를 추가한다**
+- [x] **Step 3: 수동 스크롤 suspend 상태를 추가한다**
 
 `src/components/preview/MarkdownPreview.tsx`에 상수와 refs를 추가한다.
 
@@ -749,7 +749,7 @@ onScroll={() => {
 }}
 ```
 
-- [ ] **Step 4: suspend 만료 후 다시 따라가는 테스트를 추가한다**
+- [x] **Step 4: suspend 만료 후 다시 따라가는 테스트를 추가한다**
 
 같은 파일에 다음 테스트를 추가한다.
 
@@ -848,13 +848,13 @@ it("resumes auto-scroll after the manual scroll suspension expires", () => {
 });
 ```
 
-- [ ] **Step 5: 테스트 통과를 확인한다**
+- [x] **Step 5: 테스트 통과를 확인한다**
 
 Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
 
 Expected: PASS.
 
-- [ ] **Step 6: 변경을 커밋한다**
+- [x] **Step 6: 변경을 커밋한다**
 
 ```bash
 git add src/components/preview/MarkdownPreview.tsx src/components/preview/MarkdownPreview.test.tsx

--- a/docs/superpowers/plans/2026-05-22-preview-auto-scroll.md
+++ b/docs/superpowers/plans/2026-05-22-preview-auto-scroll.md
@@ -386,7 +386,7 @@ git commit -m "fix(preview): sync scroll by anchor block"
 - Modify: `src/components/preview/MarkdownPreview.tsx`
 - Modify: `src/components/preview/MarkdownPreview.test.tsx`
 
-- [ ] **Step 1: `requestAnimationFrame` 기반 동기화 테스트를 준비한다**
+- [x] **Step 1: `requestAnimationFrame` 기반 동기화 테스트를 준비한다**
 
 `src/components/preview/MarkdownPreview.test.tsx`의 `afterEach`에 fake timer cleanup이 없다면 각 테스트 안에서 `vi.useFakeTimers()`와 `vi.useRealTimers()`를 사용한다. 새 테스트는 다음 형태로 추가한다.
 
@@ -472,7 +472,7 @@ it("coalesces rapid active line changes into the latest scheduled scroll", () =>
 });
 ```
 
-- [ ] **Step 2: 기존 layoutVersion 테스트를 새 정책에 맞게 바꾼다**
+- [x] **Step 2: 기존 layoutVersion 테스트를 새 정책에 맞게 바꾼다**
 
 기존 `"re-syncs preview scrolling when the layout version changes"` 테스트는 삭제하거나 다음 기대값으로 바꾼다.
 
@@ -518,13 +518,13 @@ it("does not scroll solely because the layout version changes", () => {
 });
 ```
 
-- [ ] **Step 3: 테스트 실패를 확인한다**
+- [x] **Step 3: 테스트 실패를 확인한다**
 
 Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
 
 Expected: FAIL because sync is still immediate or layoutVersion still resets and scrolls.
 
-- [ ] **Step 4: pending animation frame ref와 예약 함수를 추가한다**
+- [x] **Step 4: pending animation frame ref와 예약 함수를 추가한다**
 
 `src/components/preview/MarkdownPreview.tsx`에 ref와 cleanup을 추가한다.
 
@@ -571,13 +571,13 @@ useEffect(() => {
 }, [cancelPendingPreviewScroll]);
 ```
 
-- [ ] **Step 5: 테스트 통과를 확인한다**
+- [x] **Step 5: 테스트 통과를 확인한다**
 
 Run: `npm run test -- src/components/preview/MarkdownPreview.test.tsx`
 
 Expected: PASS.
 
-- [ ] **Step 6: 변경을 커밋한다**
+- [x] **Step 6: 변경을 커밋한다**
 
 ```bash
 git add src/components/preview/MarkdownPreview.tsx src/components/preview/MarkdownPreview.test.tsx

--- a/docs/superpowers/specs/2026-05-22-preview-auto-scroll-design.md
+++ b/docs/superpowers/specs/2026-05-22-preview-auto-scroll-design.md
@@ -1,0 +1,101 @@
+# Preview Auto Scroll Stabilization Design
+
+## 배경 및 의도
+
+ClipMark는 로컬 Markdown 파일을 좌측 편집 패널에서 작성하고 우측 미리보기 패널에서 읽는 split editor다. 현재 미리보기 자동 스크롤은 에디터의 활성 줄을 기준으로 가장 가까운 preview anchor를 찾아 이동한다. 이 기능의 의도는 좋지만, 입력 중 `previewHtml` 재생성과 `ResizeObserver` 변화가 같은 줄에 대한 스크롤 동기화를 반복 실행하면서 미리보기 패널이 흔들릴 수 있다.
+
+이번 변경의 목표는 자동 스크롤의 기준을 명확히 해서 사용자가 입력하는 동안 미리보기가 불필요하게 재배치되지 않게 만드는 것이다. 기능 원칙은 유지한다. 에디터의 활성 줄이 앵커 가능한 다른 Markdown 블록으로 이동했을 때, 미리보기는 해당 블록이 보이도록 따라가야 한다.
+
+## 목표
+
+- 에디터 활성 줄이 다른 preview anchor 블록으로 이동했을 때만 미리보기를 자동 스크롤한다.
+- 같은 문단, 리스트 항목, 코드블록, 표 등 같은 anchor 범위 안에서 입력할 때는 미리보기를 다시 스크롤하지 않는다.
+- Markdown 재렌더는 anchor 목록을 갱신하되, 그 자체가 자동 스크롤 명령이 되지 않는다.
+- 패널 레이아웃 변화와 ResizeObserver 콜백은 스크롤 상태를 흔들지 않도록 보조 이벤트로 취급한다.
+- 사용자가 미리보기 패널을 직접 스크롤하면 자동 추적을 잠시 멈춘다.
+- 입력 중 자동 스크롤은 즉시 이동을 사용하고, `smooth` 스크롤은 명시적 이동 같은 별도 사용자 명령에서만 사용할 수 있게 경계를 남긴다.
+
+## 비목표
+
+- 에디터 스크롤 위치와 미리보기 스크롤 비율을 양방향으로 동기화하지 않는다.
+- 미리보기에서 클릭한 위치로 에디터 커서를 이동하는 기능은 추가하지 않는다.
+- Markdown renderer의 source map 정밀도를 문단 내부 character 단위까지 확장하지 않는다.
+- UI 토글이나 설정 화면을 새로 만들지 않는다.
+
+## 현재 구조
+
+- `src/components/editor/MarkdownEditor.tsx`
+  - CodeMirror update listener가 `docChanged` 시 document store에 변경을 알린다.
+  - `docChanged` 또는 `selectionSet` 시 현재 커서 줄을 `EditorViewStateStore`에 기록한다.
+- `src/components/workspace/EditorWorkspace.tsx`
+  - document store에서 markdown을 읽고 `useDeferredValue`, debounce, idle value를 거쳐 `MarkdownPreview`로 전달한다.
+  - 에디터가 focused 상태일 때만 미리보기 자동 스크롤을 켠다.
+- `src/components/preview/MarkdownPreview.tsx`
+  - `previewHtml`을 렌더링하고 `[data-source-line-start]` 요소들을 anchor로 수집한다.
+  - `activeLine`, `previewHtml`, `layoutVersion`, `ResizeObserver` 변화에서 `syncPreviewScroll()`을 호출한다.
+- `src/lib/preview-scroll.ts`
+  - 활성 줄에 가장 가까운 preview anchor를 찾는다.
+
+## 제안 설계
+
+### 1. 스크롤 트리거 분리
+
+`MarkdownPreview`는 preview DOM이 바뀔 때 anchor 목록만 갱신한다. `previewHtml` 변경 effect는 `syncPreviewScroll()`을 직접 호출하지 않는다. 자동 스크롤은 기본적으로 `activeLine` 변경 effect에서만 예약한다.
+
+레이아웃 변화는 별도 reason으로 처리한다. `layoutVersion` 변경이나 ResizeObserver 콜백은 anchor가 현재 viewport에서 완전히 벗어난 경우에만 보정할 수 있지만, 초기 구현에서는 불필요한 움직임을 피하기 위해 직접 스크롤하지 않는다.
+
+### 2. 줄 단위가 아닌 anchor 단위 중복 방지
+
+현재 `lastSyncedLineRef`는 같은 줄 중복만 막는다. 입력 중 markdown이 재렌더되면 이 값이 초기화되어 같은 줄도 다시 스크롤될 수 있다.
+
+새 기준은 `lineStart:lineEnd` 형태의 anchor key다. 활성 줄이 같은 anchor 범위 안에 있으면 line number가 바뀌어도 스크롤하지 않는다. 예를 들어 문단이 `12-16` 줄에 매핑되어 있으면, 커서가 12, 13, 14, 15, 16줄 사이를 오가도 미리보기 위치는 유지된다.
+
+### 3. 스크롤 예약과 DOM 측정 안정화
+
+자동 스크롤은 즉시 DOM을 측정하지 않고 `requestAnimationFrame`으로 예약한다. 같은 frame 안에서 여러 activeLine 변경이 발생하면 이전 예약을 취소하고 최신 activeLine만 처리한다. 이 방식은 React 렌더와 `dangerouslySetInnerHTML` 반영 직후 layout 측정을 안정화한다.
+
+### 4. 수동 스크롤 존중
+
+미리보기 컨테이너에 `scroll`, `wheel`, pointer 기반 스크롤 신호를 감지한다. 프로그램이 발생시킨 스크롤과 사용자가 발생시킨 스크롤을 구분하기 위해 `isProgrammaticScrollRef`를 둔다. 수동 스크롤이 감지되면 짧은 시간 동안 자동 추적을 중단한다.
+
+자동 추적 재개 조건은 보수적으로 둔다.
+
+- activeLine이 마지막으로 동기화한 anchor와 다른 anchor로 이동한다.
+- suspend 시간이 지난 뒤 activeLine 변경이 다시 발생한다.
+- 에디터 focus가 다시 들어오고 현재 anchor가 viewport 밖에 있다.
+
+### 5. 스크롤 behavior 정책
+
+입력 중 자동 추적은 `behavior: "auto"`를 사용한다. `smooth`는 애니메이션이 중첩될 수 있어 타이핑 중 흔들림을 키운다. 향후 TOC 클릭 또는 명시적 heading 이동에서 preview를 함께 이동시키는 기능을 추가할 경우, 그 경로에서만 `smooth`를 사용할 수 있도록 `scrollPreviewTo(container, top, behavior)` 형태로 함수 경계를 바꾼다.
+
+## 파일별 책임
+
+- `src/lib/preview-scroll.ts`
+  - active line에 대응하는 anchor 탐색.
+  - anchor key 생성.
+  - viewport 안에서 anchor가 안정 영역에 들어와 있는지 판단하는 순수 helper를 둘 수 있다.
+- `src/components/preview/MarkdownPreview.tsx`
+  - DOM ref, anchor 목록, pending animation frame, 수동 스크롤 suspend 상태를 관리한다.
+  - `activeLine` 변경을 자동 스크롤의 주 트리거로 삼는다.
+  - `previewHtml` 변경은 anchor 목록만 갱신한다.
+- `src/components/preview/MarkdownPreview.test.tsx`
+  - 같은 anchor 내부 입력, previewHtml 재렌더, 다른 anchor 이동, 수동 스크롤 suspend, behavior 정책을 검증한다.
+
+## 테스트 전략
+
+- `preview-scroll` 순수 helper는 anchor key와 탐색 규칙을 단위 테스트로 검증한다.
+- `MarkdownPreview`는 jsdom에서 `getBoundingClientRect`, `clientHeight`, `scrollHeight`, `scrollTo`, `requestAnimationFrame`을 제어해 스크롤 호출 여부와 behavior를 검증한다.
+- 기존 링크 열기 테스트와 layoutVersion 관련 테스트가 새 정책과 충돌하면 새 정책에 맞게 기대값을 바꾼다.
+- 변경 후 `npm run test -- src/lib/preview-scroll.test.ts src/components/preview/MarkdownPreview.test.tsx`를 먼저 실행하고, 최종적으로 `npm run test`를 실행한다.
+
+## 의사결정
+
+스크롤 비율 기반 동기화는 이번 범위에서 제외한다. 비율 동기화는 문서 탐색 경험에는 유용할 수 있지만, source markdown과 rendered preview의 높이 분포가 다르면 정확도가 낮고, 이미지나 코드블록 로딩에 따라 계속 보정이 필요하다. 현재 문제는 편집 중 active line 기반 자동 스크롤이 과도하게 실행되는 것이므로, 같은 모델을 더 안정적으로 만드는 편이 비용과 효과의 균형이 좋다.
+
+## 성공 기준
+
+- 같은 anchor 블록 안에서 타이핑할 때 미리보기 `scrollTo`가 반복 호출되지 않는다.
+- 활성 줄이 다른 anchor 블록으로 이동하고 그 anchor가 안정 영역 밖에 있으면 미리보기가 한 번 이동한다.
+- preview HTML 재렌더만으로는 미리보기가 이동하지 않는다.
+- 사용자가 preview를 직접 스크롤한 직후에는 자동 스크롤이 개입하지 않는다.
+- 입력 중 자동 스크롤 호출은 `behavior: "auto"`를 사용한다.

--- a/src/components/preview/MarkdownPreview.test.tsx
+++ b/src/components/preview/MarkdownPreview.test.tsx
@@ -763,6 +763,20 @@ describe("MarkdownPreview", () => {
   });
 
   it("does not scroll again when only the preview html changes for the same active anchor", () => {
+    vi.useFakeTimers();
+    cleanupHandlers.push(() => vi.useRealTimers());
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation((handle) => window.clearTimeout(handle));
+    cleanupHandlers.push(() => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    });
+
     const renderer = createTestRenderer();
     cleanupHandlers.push(() => renderer.cleanup());
 
@@ -811,14 +825,194 @@ describe("MarkdownPreview", () => {
       activeLine: 5,
       markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
     });
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
     const initialCallCount = scrollTo.mock.calls.length;
+    expect(initialCallCount).toBeGreaterThan(0);
 
     renderer.render({
       activeLine: 5,
       markdown: "# Heading\n\nFirst paragraph\n\n## Section updated\n\nSecond paragraph",
     });
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
 
     expect(scrollTo).toHaveBeenCalledTimes(initialCallCount);
+  });
+
+  it("scrolls after refreshed preview html adds the active off-screen anchor", () => {
+    vi.useFakeTimers();
+    cleanupHandlers.push(() => vi.useRealTimers());
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation((handle) => window.clearTimeout(handle));
+    cleanupHandlers.push(() => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    });
+
+    const renderer = createTestRenderer();
+    cleanupHandlers.push(() => renderer.cleanup());
+
+    const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+      this.scrollTop = options.top ?? 0;
+    });
+    const originalScrollTo = HTMLElement.prototype.scrollTo;
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+      writable: true,
+    });
+    cleanupHandlers.push(() => {
+      if (originalScrollTo) {
+        Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+          configurable: true,
+          value: originalScrollTo,
+          writable: true,
+        });
+        return;
+      }
+
+      delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+    });
+
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 1400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+      if (this.classList.contains("markdown-preview")) {
+        return new DOMRect(0, 0, 320, 400);
+      }
+
+      const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
+      if (lineStart === 3) {
+        return new DOMRect(0, 120, 320, 48);
+      }
+      if (lineStart === 7) {
+        return new DOMRect(0, 760, 320, 48);
+      }
+
+      return new DOMRect(0, 0, 0, 0);
+    });
+
+    renderer.render({
+      activeLine: 7,
+      markdown: "# Heading\n\nExisting paragraph",
+    });
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    renderer.render({
+      activeLine: 7,
+      markdown: "# Heading\n\nExisting paragraph\n\n## Added section\n\nNew target paragraph",
+    });
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({
+      top: 640,
+    }));
+  });
+
+  it("keeps auto-scroll suspended when pointer intent precedes a scroll during programmatic fallback", () => {
+    vi.useFakeTimers();
+    cleanupHandlers.push(() => vi.useRealTimers());
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation((handle) => window.clearTimeout(handle));
+    cleanupHandlers.push(() => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    });
+
+    const renderer = createTestRenderer();
+    cleanupHandlers.push(() => renderer.cleanup());
+
+    const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+      this.scrollTop = options.top ?? 0;
+    });
+    const originalScrollTo = HTMLElement.prototype.scrollTo;
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+      writable: true,
+    });
+    cleanupHandlers.push(() => {
+      if (originalScrollTo) {
+        Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+          configurable: true,
+          value: originalScrollTo,
+          writable: true,
+        });
+        return;
+      }
+
+      delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+    });
+
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 1400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+      if (this.classList.contains("markdown-preview")) {
+        return new DOMRect(0, 0, 320, 400);
+      }
+
+      const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
+      if (lineStart === 5) {
+        return new DOMRect(0, 520, 320, 48);
+      }
+      if (lineStart === 7) {
+        return new DOMRect(0, 760, 320, 48);
+      }
+
+      return new DOMRect(0, 0, 0, 0);
+    });
+
+    renderer.render({
+      activeLine: 5,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    const previewElement = renderer.container.querySelector(".markdown-preview") as HTMLDivElement;
+    act(() => {
+      previewElement.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+      previewElement.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    const callCountAfterManualScroll = scrollTo.mock.calls.length;
+    renderer.render({
+      activeLine: 7,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    expect(scrollTo).toHaveBeenCalledTimes(callCountAfterManualScroll);
   });
 
   it("does not scroll the preview when auto-scroll is disabled", () => {

--- a/src/components/preview/MarkdownPreview.test.tsx
+++ b/src/components/preview/MarkdownPreview.test.tsx
@@ -138,13 +138,32 @@ describe("MarkdownPreview", () => {
     });
 
     expect(scrollTo).toHaveBeenCalledTimes(1);
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({
+      top: 640,
+    }));
   });
 
   it("does not scroll solely because the layout version changes", () => {
+    vi.useFakeTimers();
+    cleanupHandlers.push(() => vi.useRealTimers());
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation((handle) => window.clearTimeout(handle));
+    cleanupHandlers.push(() => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    });
+
     const renderer = createTestRenderer();
     cleanupHandlers.push(() => renderer.cleanup());
 
-    const scrollTo = vi.fn();
+    const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+      this.scrollTop = options.top ?? 0;
+    });
     const originalScrollTo = HTMLElement.prototype.scrollTo;
     Object.defineProperty(HTMLElement.prototype, "scrollTo", {
       configurable: true,
@@ -164,20 +183,81 @@ describe("MarkdownPreview", () => {
       delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
     });
 
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 1200 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+      if (this.classList.contains("markdown-preview")) {
+        return new DOMRect(0, 0, 320, 400);
+      }
+
+      const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
+      if (lineStart === 5) {
+        return new DOMRect(0, 520, 320, 48);
+      }
+
+      return new DOMRect(0, 0, 0, 0);
+    });
+
     renderer.render({
       activeLine: 5,
       layoutVersion: 0,
       markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
     });
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
     const initialCallCount = scrollTo.mock.calls.length;
+    expect(initialCallCount).toBeGreaterThan(0);
 
     renderer.render({
       activeLine: 5,
       layoutVersion: 1,
       markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
     });
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
 
     expect(scrollTo).toHaveBeenCalledTimes(initialCallCount);
+  });
+
+  it("cancels a pending scheduled preview scroll on unmount", () => {
+    vi.useFakeTimers();
+    cleanupHandlers.push(() => vi.useRealTimers());
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation((handle) => window.clearTimeout(handle));
+    cleanupHandlers.push(() => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    });
+
+    const renderer = createTestRenderer();
+    let didCleanup = false;
+    cleanupHandlers.push(() => {
+      if (!didCleanup) {
+        renderer.cleanup();
+      }
+    });
+
+    renderer.render({
+      activeLine: 5,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+    expect(requestAnimationFrameSpy).toHaveBeenCalled();
+
+    renderer.cleanup();
+    didCleanup = true;
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalled();
   });
 
   it("opens resolved links through delegated click handling", () => {

--- a/src/components/preview/MarkdownPreview.test.tsx
+++ b/src/components/preview/MarkdownPreview.test.tsx
@@ -143,6 +143,191 @@ describe("MarkdownPreview", () => {
     }));
   });
 
+  it("temporarily suspends auto-scroll after the user scrolls the preview", () => {
+    vi.useFakeTimers();
+    cleanupHandlers.push(() => vi.useRealTimers());
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation((handle) => window.clearTimeout(handle));
+    cleanupHandlers.push(() => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    });
+
+    const renderer = createTestRenderer();
+    cleanupHandlers.push(() => renderer.cleanup());
+
+    const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+      this.scrollTop = options.top ?? 0;
+      this.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    const originalScrollTo = HTMLElement.prototype.scrollTo;
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+      writable: true,
+    });
+    cleanupHandlers.push(() => {
+      if (originalScrollTo) {
+        Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+          configurable: true,
+          value: originalScrollTo,
+          writable: true,
+        });
+        return;
+      }
+
+      delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+    });
+
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 1400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+      if (this.classList.contains("markdown-preview")) {
+        return new DOMRect(0, 0, 320, 400);
+      }
+
+      const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
+      if (lineStart === 5) {
+        return new DOMRect(0, 520, 320, 48);
+      }
+      if (lineStart === 7) {
+        return new DOMRect(0, 760, 320, 48);
+      }
+
+      return new DOMRect(0, 0, 0, 0);
+    });
+
+    renderer.render({
+      activeLine: 5,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    const previewElement = renderer.container.querySelector(".markdown-preview") as HTMLDivElement;
+    act(() => {
+      previewElement.dispatchEvent(new WheelEvent("wheel", { bubbles: true }));
+      previewElement.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    const callCountAfterManualScroll = scrollTo.mock.calls.length;
+
+    renderer.render({
+      activeLine: 7,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    expect(scrollTo).toHaveBeenCalledTimes(callCountAfterManualScroll);
+  });
+
+  it("resumes auto-scroll after the manual scroll suspension expires", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-22T00:00:00.000Z"));
+    cleanupHandlers.push(() => {
+      vi.useRealTimers();
+    });
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation((handle) => window.clearTimeout(handle));
+    cleanupHandlers.push(() => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    });
+
+    const renderer = createTestRenderer();
+    cleanupHandlers.push(() => renderer.cleanup());
+
+    const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+      this.scrollTop = options.top ?? 0;
+    });
+    const originalScrollTo = HTMLElement.prototype.scrollTo;
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+      writable: true,
+    });
+    cleanupHandlers.push(() => {
+      if (originalScrollTo) {
+        Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+          configurable: true,
+          value: originalScrollTo,
+          writable: true,
+        });
+        return;
+      }
+
+      delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+    });
+
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 1400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+      if (this.classList.contains("markdown-preview")) {
+        return new DOMRect(0, 0, 320, 400);
+      }
+
+      const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
+      if (lineStart === 5) {
+        return new DOMRect(0, 520, 320, 48);
+      }
+      if (lineStart === 7) {
+        return new DOMRect(0, 760, 320, 48);
+      }
+
+      return new DOMRect(0, 0, 0, 0);
+    });
+
+    renderer.render({
+      activeLine: 5,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    const previewElement = renderer.container.querySelector(".markdown-preview") as HTMLDivElement;
+    act(() => {
+      previewElement.dispatchEvent(new WheelEvent("wheel", { bubbles: true }));
+      vi.advanceTimersByTime(901);
+    });
+
+    const callCountBeforeResume = scrollTo.mock.calls.length;
+    renderer.render({
+      activeLine: 7,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    expect(scrollTo.mock.calls.length).toBeGreaterThan(callCountBeforeResume);
+  });
+
   it("does not scroll solely because the layout version changes", () => {
     vi.useFakeTimers();
     cleanupHandlers.push(() => vi.useRealTimers());

--- a/src/components/preview/MarkdownPreview.test.tsx
+++ b/src/components/preview/MarkdownPreview.test.tsx
@@ -235,6 +235,101 @@ describe("MarkdownPreview", () => {
     expect(scrollTo).toHaveBeenCalledTimes(callCountAfterManualScroll);
   });
 
+  it("does not suspend auto-scroll when a programmatic scroll event arrives later", () => {
+    vi.useFakeTimers();
+    cleanupHandlers.push(() => vi.useRealTimers());
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation((handle) => window.clearTimeout(handle));
+    cleanupHandlers.push(() => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    });
+
+    const renderer = createTestRenderer();
+    cleanupHandlers.push(() => renderer.cleanup());
+
+    const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+      this.scrollTop = options.top ?? 0;
+      window.setTimeout(() => {
+        this.dispatchEvent(new Event("scroll", { bubbles: true }));
+      }, 100);
+    });
+    const originalScrollTo = HTMLElement.prototype.scrollTo;
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+      writable: true,
+    });
+    cleanupHandlers.push(() => {
+      if (originalScrollTo) {
+        Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+          configurable: true,
+          value: originalScrollTo,
+          writable: true,
+        });
+        return;
+      }
+
+      delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+    });
+
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 1400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+      if (this.classList.contains("markdown-preview")) {
+        return new DOMRect(0, 0, 320, 400);
+      }
+
+      const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
+      if (lineStart === 5) {
+        return new DOMRect(0, 520, 320, 48);
+      }
+      if (lineStart === 7) {
+        return new DOMRect(0, 760, 320, 48);
+      }
+
+      return new DOMRect(0, 0, 0, 0);
+    });
+
+    renderer.render({
+      activeLine: 5,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(99);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    const callCountBeforeLineChange = scrollTo.mock.calls.length;
+    renderer.render({
+      activeLine: 7,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    expect(scrollTo.mock.calls.length).toBeGreaterThan(callCountBeforeLineChange);
+  });
+
   it("resumes auto-scroll after the manual scroll suspension expires", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-22T00:00:00.000Z"));

--- a/src/components/preview/MarkdownPreview.test.tsx
+++ b/src/components/preview/MarkdownPreview.test.tsx
@@ -241,9 +241,67 @@ describe("MarkdownPreview", () => {
     const previewElement = renderer.container.querySelector(".markdown-preview") as HTMLDivElement | null;
     expect(previewElement).toBeTruthy();
     expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({
-      behavior: "smooth",
+      behavior: "auto",
     }));
     expect(previewElement?.scrollTop).toBeGreaterThan(0);
+  });
+
+  it("does not scroll while the active line stays inside the same preview anchor", () => {
+    const renderer = createTestRenderer();
+    cleanupHandlers.push(() => renderer.cleanup());
+
+    const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+      this.scrollTop = options.top ?? 0;
+    });
+    const originalScrollTo = HTMLElement.prototype.scrollTo;
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+      writable: true,
+    });
+    cleanupHandlers.push(() => {
+      if (originalScrollTo) {
+        Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+          configurable: true,
+          value: originalScrollTo,
+          writable: true,
+        });
+        return;
+      }
+
+      delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+    });
+
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 1200 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+      if (this.classList.contains("markdown-preview")) {
+        return new DOMRect(0, 0, 320, 400);
+      }
+
+      if (this.dataset.sourceLineStart === "1") {
+        return new DOMRect(0, 520, 320, 120);
+      }
+
+      return new DOMRect(0, 0, 0, 0);
+    });
+
+    renderer.render({
+      activeLine: 1,
+      markdown: "First line\nSecond line\nThird line",
+    });
+    const initialCallCount = scrollTo.mock.calls.length;
+
+    renderer.render({
+      activeLine: 2,
+      markdown: "First line\nSecond line\nThird line",
+    });
+
+    expect(scrollTo).toHaveBeenCalledTimes(initialCallCount);
   });
 
   it("does not scroll again when only the preview html changes for the same active anchor", () => {

--- a/src/components/preview/MarkdownPreview.test.tsx
+++ b/src/components/preview/MarkdownPreview.test.tsx
@@ -60,40 +60,24 @@ afterEach(() => {
 });
 
 describe("MarkdownPreview", () => {
-  it("re-syncs preview scrolling when the layout version changes", () => {
+  it("coalesces rapid active line changes into the latest scheduled scroll", () => {
+    vi.useFakeTimers();
+    cleanupHandlers.push(() => vi.useRealTimers());
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation((handle) => window.clearTimeout(handle));
+    cleanupHandlers.push(() => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    });
+
     const renderer = createTestRenderer();
     cleanupHandlers.push(() => renderer.cleanup());
-    renderer.render({
-      activeLine: 5,
-      layoutVersion: 0,
-      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
-    });
 
-    const topByLineStart = new Map([
-      [1, 16],
-      [3, 180],
-      [5, 520],
-      [7, 760],
-    ]);
-    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
-      return this.classList.contains("markdown-preview") ? 400 : 0;
-    });
-    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
-      return this.classList.contains("markdown-preview") ? 1200 : 0;
-    });
-    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
-      if (this.classList.contains("markdown-preview")) {
-        return new DOMRect(0, 0, 320, 400);
-      }
-
-      const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
-      const top = topByLineStart.get(lineStart);
-      if (top !== undefined) {
-        return new DOMRect(0, top, 320, 48);
-      }
-
-      return new DOMRect(0, 0, 0, 0);
-    });
     const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
       this.scrollTop = options.top ?? 0;
     });
@@ -116,13 +100,84 @@ describe("MarkdownPreview", () => {
       delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
     });
 
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 1400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+      if (this.classList.contains("markdown-preview")) {
+        return new DOMRect(0, 0, 320, 400);
+      }
+
+      const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
+      if (lineStart === 5) {
+        return new DOMRect(0, 520, 320, 48);
+      }
+      if (lineStart === 7) {
+        return new DOMRect(0, 760, 320, 48);
+      }
+
+      return new DOMRect(0, 0, 0, 0);
+    });
+
+    renderer.render({
+      activeLine: 5,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+    renderer.render({
+      activeLine: 7,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not scroll solely because the layout version changes", () => {
+    const renderer = createTestRenderer();
+    cleanupHandlers.push(() => renderer.cleanup());
+
+    const scrollTo = vi.fn();
+    const originalScrollTo = HTMLElement.prototype.scrollTo;
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+      writable: true,
+    });
+    cleanupHandlers.push(() => {
+      if (originalScrollTo) {
+        Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+          configurable: true,
+          value: originalScrollTo,
+          writable: true,
+        });
+        return;
+      }
+
+      delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+    });
+
+    renderer.render({
+      activeLine: 5,
+      layoutVersion: 0,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+    const initialCallCount = scrollTo.mock.calls.length;
+
     renderer.render({
       activeLine: 5,
       layoutVersion: 1,
       markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
     });
 
-    expect(scrollTo).toHaveBeenCalled();
+    expect(scrollTo).toHaveBeenCalledTimes(initialCallCount);
   });
 
   it("opens resolved links through delegated click handling", () => {
@@ -178,6 +233,20 @@ describe("MarkdownPreview", () => {
   });
 
   it("scrolls the preview when the active line changes to an off-screen block", () => {
+    vi.useFakeTimers();
+    cleanupHandlers.push(() => vi.useRealTimers());
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation((handle) => window.clearTimeout(handle));
+    cleanupHandlers.push(() => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    });
+
     const renderer = createTestRenderer();
     cleanupHandlers.push(() => renderer.cleanup());
     renderer.render({
@@ -238,6 +307,10 @@ describe("MarkdownPreview", () => {
       markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
     });
 
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
     const previewElement = renderer.container.querySelector(".markdown-preview") as HTMLDivElement | null;
     expect(previewElement).toBeTruthy();
     expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({
@@ -247,6 +320,20 @@ describe("MarkdownPreview", () => {
   });
 
   it("does not scroll while the active line stays inside the same preview anchor", () => {
+    vi.useFakeTimers();
+    cleanupHandlers.push(() => vi.useRealTimers());
+
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => window.setTimeout(() => callback(performance.now()), 16));
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation((handle) => window.clearTimeout(handle));
+    cleanupHandlers.push(() => {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    });
+
     const renderer = createTestRenderer();
     cleanupHandlers.push(() => renderer.cleanup());
 
@@ -294,6 +381,10 @@ describe("MarkdownPreview", () => {
       activeLine: 1,
       markdown: "First line\nSecond line\nThird line",
     });
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
     const anchor = renderer.container.querySelector<HTMLElement>("[data-source-line-start='1']");
     expect(anchor).toBeInstanceOf(HTMLElement);
     expect(anchor?.dataset.sourceLineEnd).toBe("3");
@@ -303,6 +394,9 @@ describe("MarkdownPreview", () => {
     renderer.render({
       activeLine: 2,
       markdown: "First line\nSecond line\nThird line",
+    });
+    act(() => {
+      vi.advanceTimersByTime(16);
     });
 
     expect(scrollTo).toHaveBeenCalledTimes(initialCallCount);

--- a/src/components/preview/MarkdownPreview.test.tsx
+++ b/src/components/preview/MarkdownPreview.test.tsx
@@ -294,7 +294,11 @@ describe("MarkdownPreview", () => {
       activeLine: 1,
       markdown: "First line\nSecond line\nThird line",
     });
+    const anchor = renderer.container.querySelector<HTMLElement>("[data-source-line-start='1']");
+    expect(anchor).toBeInstanceOf(HTMLElement);
+    expect(anchor?.dataset.sourceLineEnd).toBe("3");
     const initialCallCount = scrollTo.mock.calls.length;
+    expect(initialCallCount).toBeGreaterThan(0);
 
     renderer.render({
       activeLine: 2,

--- a/src/components/preview/MarkdownPreview.test.tsx
+++ b/src/components/preview/MarkdownPreview.test.tsx
@@ -246,6 +246,65 @@ describe("MarkdownPreview", () => {
     expect(previewElement?.scrollTop).toBeGreaterThan(0);
   });
 
+  it("does not scroll again when only the preview html changes for the same active anchor", () => {
+    const renderer = createTestRenderer();
+    cleanupHandlers.push(() => renderer.cleanup());
+
+    const originalScrollTo = HTMLElement.prototype.scrollTo;
+    const scrollTo = vi.fn(function setScrollTop(this: HTMLElement, options: ScrollToOptions) {
+      this.scrollTop = options.top ?? 0;
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+      writable: true,
+    });
+    cleanupHandlers.push(() => {
+      if (originalScrollTo) {
+        Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+          configurable: true,
+          value: originalScrollTo,
+          writable: true,
+        });
+        return;
+      }
+
+      delete (HTMLElement.prototype as Partial<HTMLElement>).scrollTo;
+    });
+
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function getClientHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 400 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function getScrollHeight(this: HTMLElement) {
+      return this.classList.contains("markdown-preview") ? 1200 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
+      if (this.classList.contains("markdown-preview")) {
+        return new DOMRect(0, 0, 320, 400);
+      }
+
+      const lineStart = Number(this.dataset.sourceLineStart ?? NaN);
+      if (lineStart === 5) {
+        return new DOMRect(0, 520, 320, 48);
+      }
+
+      return new DOMRect(0, 0, 0, 0);
+    });
+
+    renderer.render({
+      activeLine: 5,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section\n\nSecond paragraph",
+    });
+    const initialCallCount = scrollTo.mock.calls.length;
+
+    renderer.render({
+      activeLine: 5,
+      markdown: "# Heading\n\nFirst paragraph\n\n## Section updated\n\nSecond paragraph",
+    });
+
+    expect(scrollTo).toHaveBeenCalledTimes(initialCallCount);
+  });
+
   it("does not scroll the preview when auto-scroll is disabled", () => {
     const renderer = createTestRenderer();
     cleanupHandlers.push(() => renderer.cleanup());

--- a/src/components/preview/MarkdownPreview.tsx
+++ b/src/components/preview/MarkdownPreview.tsx
@@ -21,12 +21,18 @@ type PreviewAnchorElement = PreviewScrollAnchor & {
   element: HTMLElement;
 };
 
-function scrollPreviewTo(container: HTMLDivElement, top: number) {
+type PreviewScrollBehavior = ScrollBehavior;
+
+function scrollPreviewTo(
+  container: HTMLDivElement,
+  top: number,
+  behavior: PreviewScrollBehavior,
+) {
   const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
   if (typeof container.scrollTo === "function") {
     container.scrollTo({
-      behavior: prefersReducedMotion ? "auto" : "smooth",
+      behavior: prefersReducedMotion ? "auto" : behavior,
       top,
     });
     return;
@@ -97,7 +103,7 @@ export function MarkdownPreview({
       ),
     );
 
-    scrollPreviewTo(container, nextScrollTop);
+    scrollPreviewTo(container, nextScrollTop, "auto");
     lastSyncedAnchorKeyRef.current = targetAnchorKey;
   });
 

--- a/src/components/preview/MarkdownPreview.tsx
+++ b/src/components/preview/MarkdownPreview.tsx
@@ -97,6 +97,11 @@ export function MarkdownPreview({
 
     return true;
   });
+  const suspendAutoScrollForManualIntent = useEffectEvent(() => {
+    pendingProgrammaticScrollRef.current = 0;
+    clearProgrammaticScrollFallback();
+    manualScrollSuspendUntilRef.current = Date.now() + MANUAL_SCROLL_SUSPEND_MS;
+  });
   const syncPreviewScroll = useEffectEvent(() => {
     if (!isAutoScrollEnabled || activeLine === null || isLayoutTransitioning) {
       return;
@@ -190,7 +195,8 @@ export function MarkdownPreview({
       })
       .filter((anchor): anchor is PreviewAnchorElement => anchor !== null);
 
-  }, [previewHtml]);
+    schedulePreviewScroll();
+  }, [previewHtml, schedulePreviewScroll]);
 
   useEffect(() => {
     schedulePreviewScroll();
@@ -248,6 +254,8 @@ export function MarkdownPreview({
       onWheel={() => {
         manualScrollSuspendUntilRef.current = Date.now() + MANUAL_SCROLL_SUSPEND_MS;
       }}
+      onPointerDown={suspendAutoScrollForManualIntent}
+      onTouchStart={suspendAutoScrollForManualIntent}
       onScroll={() => {
         if (consumeProgrammaticScroll()) {
           return;

--- a/src/components/preview/MarkdownPreview.tsx
+++ b/src/components/preview/MarkdownPreview.tsx
@@ -48,11 +48,11 @@ export function MarkdownPreview({
   isAutoScrollEnabled,
   isExternalMediaAutoLoadEnabled,
   isLayoutTransitioning = false,
-  layoutVersion = 0,
 }: MarkdownPreviewProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const anchorsRef = useRef<PreviewAnchorElement[]>([]);
   const lastSyncedAnchorKeyRef = useRef<string | null>(null);
+  const pendingScrollFrameRef = useRef<number | null>(null);
   const previewHtml = useMemo(() => {
     return renderPreviewHtml({
       filePath,
@@ -106,6 +106,21 @@ export function MarkdownPreview({
     scrollPreviewTo(container, nextScrollTop, "auto");
     lastSyncedAnchorKeyRef.current = targetAnchorKey;
   });
+  const cancelPendingPreviewScroll = useEffectEvent(() => {
+    if (pendingScrollFrameRef.current === null) {
+      return;
+    }
+
+    window.cancelAnimationFrame(pendingScrollFrameRef.current);
+    pendingScrollFrameRef.current = null;
+  });
+  const schedulePreviewScroll = useEffectEvent(() => {
+    cancelPendingPreviewScroll();
+    pendingScrollFrameRef.current = window.requestAnimationFrame(() => {
+      pendingScrollFrameRef.current = null;
+      syncPreviewScroll();
+    });
+  });
 
   useEffect(() => {
     const container = rootRef.current;
@@ -136,30 +151,14 @@ export function MarkdownPreview({
   }, [previewHtml]);
 
   useEffect(() => {
-    syncPreviewScroll();
-  }, [activeLine, isAutoScrollEnabled, isLayoutTransitioning]);
+    schedulePreviewScroll();
+  }, [activeLine, isAutoScrollEnabled, isLayoutTransitioning, schedulePreviewScroll]);
 
   useEffect(() => {
-    const container = rootRef.current;
-    if (!container || typeof ResizeObserver === "undefined" || isLayoutTransitioning) {
-      return;
-    }
-
-    const observer = new ResizeObserver(() => {
-      lastSyncedAnchorKeyRef.current = null;
-      syncPreviewScroll();
-    });
-    observer.observe(container);
-
     return () => {
-      observer.disconnect();
+      cancelPendingPreviewScroll();
     };
-  }, [isLayoutTransitioning]);
-
-  useEffect(() => {
-    lastSyncedAnchorKeyRef.current = null;
-    syncPreviewScroll();
-  }, [isLayoutTransitioning, layoutVersion]);
+  }, [cancelPendingPreviewScroll]);
 
   return (
     <div

--- a/src/components/preview/MarkdownPreview.tsx
+++ b/src/components/preview/MarkdownPreview.tsx
@@ -3,6 +3,7 @@ import { openExternalUri } from "../../lib/external-link";
 import { renderPreviewHtml } from "../../lib/preview-renderer";
 import {
   findClosestPreviewAnchor,
+  getPreviewAnchorKey,
   type PreviewScrollAnchor,
 } from "../../lib/preview-scroll";
 
@@ -45,7 +46,7 @@ export function MarkdownPreview({
 }: MarkdownPreviewProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const anchorsRef = useRef<PreviewAnchorElement[]>([]);
-  const lastSyncedLineRef = useRef<number | null>(null);
+  const lastSyncedAnchorKeyRef = useRef<string | null>(null);
   const previewHtml = useMemo(() => {
     return renderPreviewHtml({
       filePath,
@@ -64,7 +65,12 @@ export function MarkdownPreview({
     }
 
     const targetAnchor = findClosestPreviewAnchor(anchorsRef.current, activeLine);
-    if (!targetAnchor || lastSyncedLineRef.current === activeLine) {
+    if (!targetAnchor) {
+      return;
+    }
+
+    const targetAnchorKey = getPreviewAnchorKey(targetAnchor);
+    if (lastSyncedAnchorKeyRef.current === targetAnchorKey) {
       return;
     }
 
@@ -77,7 +83,7 @@ export function MarkdownPreview({
       targetRect.top >= visibleTopThreshold &&
       targetRect.top <= visibleBottomThreshold
     ) {
-      lastSyncedLineRef.current = activeLine;
+      lastSyncedAnchorKeyRef.current = targetAnchorKey;
       return;
     }
 
@@ -92,7 +98,7 @@ export function MarkdownPreview({
     );
 
     scrollPreviewTo(container, nextScrollTop);
-    lastSyncedLineRef.current = activeLine;
+    lastSyncedAnchorKeyRef.current = targetAnchorKey;
   });
 
   useEffect(() => {
@@ -121,13 +127,11 @@ export function MarkdownPreview({
       })
       .filter((anchor): anchor is PreviewAnchorElement => anchor !== null);
 
-    lastSyncedLineRef.current = null;
-    syncPreviewScroll();
-  }, [isLayoutTransitioning, previewHtml, syncPreviewScroll]);
+  }, [previewHtml]);
 
   useEffect(() => {
     syncPreviewScroll();
-  }, [activeLine, isAutoScrollEnabled, isLayoutTransitioning, syncPreviewScroll]);
+  }, [activeLine, isAutoScrollEnabled, isLayoutTransitioning]);
 
   useEffect(() => {
     const container = rootRef.current;
@@ -136,7 +140,7 @@ export function MarkdownPreview({
     }
 
     const observer = new ResizeObserver(() => {
-      lastSyncedLineRef.current = null;
+      lastSyncedAnchorKeyRef.current = null;
       syncPreviewScroll();
     });
     observer.observe(container);
@@ -144,12 +148,12 @@ export function MarkdownPreview({
     return () => {
       observer.disconnect();
     };
-  }, [isLayoutTransitioning, syncPreviewScroll]);
+  }, [isLayoutTransitioning]);
 
   useEffect(() => {
-    lastSyncedLineRef.current = null;
+    lastSyncedAnchorKeyRef.current = null;
     syncPreviewScroll();
-  }, [isLayoutTransitioning, layoutVersion, syncPreviewScroll]);
+  }, [isLayoutTransitioning, layoutVersion]);
 
   return (
     <div

--- a/src/components/preview/MarkdownPreview.tsx
+++ b/src/components/preview/MarkdownPreview.tsx
@@ -24,6 +24,7 @@ type PreviewAnchorElement = PreviewScrollAnchor & {
 type PreviewScrollBehavior = ScrollBehavior;
 
 const MANUAL_SCROLL_SUSPEND_MS = 900;
+const PROGRAMMATIC_SCROLL_FALLBACK_MS = 250;
 
 function scrollPreviewTo(
   container: HTMLDivElement,
@@ -55,7 +56,8 @@ export function MarkdownPreview({
   const anchorsRef = useRef<PreviewAnchorElement[]>([]);
   const lastSyncedAnchorKeyRef = useRef<string | null>(null);
   const pendingScrollFrameRef = useRef<number | null>(null);
-  const isProgrammaticScrollRef = useRef(false);
+  const pendingProgrammaticScrollRef = useRef(0);
+  const programmaticScrollFallbackTimeoutRef = useRef<number | null>(null);
   const manualScrollSuspendUntilRef = useRef(0);
   const previewHtml = useMemo(() => {
     return renderPreviewHtml({
@@ -66,6 +68,34 @@ export function MarkdownPreview({
   }, [filePath, isExternalMediaAutoLoadEnabled, markdown]);
   const isManualScrollSuspended = useEffectEvent(() => {
     return Date.now() < manualScrollSuspendUntilRef.current;
+  });
+  const clearProgrammaticScrollFallback = useEffectEvent(() => {
+    if (programmaticScrollFallbackTimeoutRef.current === null) {
+      return;
+    }
+
+    window.clearTimeout(programmaticScrollFallbackTimeoutRef.current);
+    programmaticScrollFallbackTimeoutRef.current = null;
+  });
+  const markProgrammaticScrollPending = useEffectEvent(() => {
+    pendingProgrammaticScrollRef.current += 1;
+    clearProgrammaticScrollFallback();
+    programmaticScrollFallbackTimeoutRef.current = window.setTimeout(() => {
+      pendingProgrammaticScrollRef.current = 0;
+      programmaticScrollFallbackTimeoutRef.current = null;
+    }, PROGRAMMATIC_SCROLL_FALLBACK_MS);
+  });
+  const consumeProgrammaticScroll = useEffectEvent(() => {
+    if (pendingProgrammaticScrollRef.current <= 0) {
+      return false;
+    }
+
+    pendingProgrammaticScrollRef.current -= 1;
+    if (pendingProgrammaticScrollRef.current === 0) {
+      clearProgrammaticScrollFallback();
+    }
+
+    return true;
   });
   const syncPreviewScroll = useEffectEvent(() => {
     if (!isAutoScrollEnabled || activeLine === null || isLayoutTransitioning) {
@@ -114,11 +144,8 @@ export function MarkdownPreview({
       ),
     );
 
-    isProgrammaticScrollRef.current = true;
+    markProgrammaticScrollPending();
     scrollPreviewTo(container, nextScrollTop, "auto");
-    window.setTimeout(() => {
-      isProgrammaticScrollRef.current = false;
-    }, 0);
     lastSyncedAnchorKeyRef.current = targetAnchorKey;
   });
   const cancelPendingPreviewScroll = useEffectEvent(() => {
@@ -172,8 +199,9 @@ export function MarkdownPreview({
   useEffect(() => {
     return () => {
       cancelPendingPreviewScroll();
+      clearProgrammaticScrollFallback();
     };
-  }, [cancelPendingPreviewScroll]);
+  }, [cancelPendingPreviewScroll, clearProgrammaticScrollFallback]);
 
   return (
     <div
@@ -221,7 +249,7 @@ export function MarkdownPreview({
         manualScrollSuspendUntilRef.current = Date.now() + MANUAL_SCROLL_SUSPEND_MS;
       }}
       onScroll={() => {
-        if (isProgrammaticScrollRef.current) {
+        if (consumeProgrammaticScroll()) {
           return;
         }
 

--- a/src/components/preview/MarkdownPreview.tsx
+++ b/src/components/preview/MarkdownPreview.tsx
@@ -23,6 +23,8 @@ type PreviewAnchorElement = PreviewScrollAnchor & {
 
 type PreviewScrollBehavior = ScrollBehavior;
 
+const MANUAL_SCROLL_SUSPEND_MS = 900;
+
 function scrollPreviewTo(
   container: HTMLDivElement,
   top: number,
@@ -53,6 +55,8 @@ export function MarkdownPreview({
   const anchorsRef = useRef<PreviewAnchorElement[]>([]);
   const lastSyncedAnchorKeyRef = useRef<string | null>(null);
   const pendingScrollFrameRef = useRef<number | null>(null);
+  const isProgrammaticScrollRef = useRef(false);
+  const manualScrollSuspendUntilRef = useRef(0);
   const previewHtml = useMemo(() => {
     return renderPreviewHtml({
       filePath,
@@ -60,8 +64,15 @@ export function MarkdownPreview({
       markdown,
     });
   }, [filePath, isExternalMediaAutoLoadEnabled, markdown]);
+  const isManualScrollSuspended = useEffectEvent(() => {
+    return Date.now() < manualScrollSuspendUntilRef.current;
+  });
   const syncPreviewScroll = useEffectEvent(() => {
     if (!isAutoScrollEnabled || activeLine === null || isLayoutTransitioning) {
+      return;
+    }
+
+    if (isManualScrollSuspended()) {
       return;
     }
 
@@ -103,7 +114,11 @@ export function MarkdownPreview({
       ),
     );
 
+    isProgrammaticScrollRef.current = true;
     scrollPreviewTo(container, nextScrollTop, "auto");
+    window.setTimeout(() => {
+      isProgrammaticScrollRef.current = false;
+    }, 0);
     lastSyncedAnchorKeyRef.current = targetAnchorKey;
   });
   const cancelPendingPreviewScroll = useEffectEvent(() => {
@@ -201,6 +216,16 @@ export function MarkdownPreview({
 
         event.preventDefault();
         void openExternalUri(previewUri);
+      }}
+      onWheel={() => {
+        manualScrollSuspendUntilRef.current = Date.now() + MANUAL_SCROLL_SUSPEND_MS;
+      }}
+      onScroll={() => {
+        if (isProgrammaticScrollRef.current) {
+          return;
+        }
+
+        manualScrollSuspendUntilRef.current = Date.now() + MANUAL_SCROLL_SUSPEND_MS;
       }}
       onKeyDown={(event) => {
         if (event.key !== "Enter" && event.key !== " ") {

--- a/src/lib/preview-scroll.test.ts
+++ b/src/lib/preview-scroll.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { findClosestPreviewAnchor } from "./preview-scroll";
+import {
+  findClosestPreviewAnchor,
+  getPreviewAnchorKey,
+} from "./preview-scroll";
+
+describe("getPreviewAnchorKey", () => {
+  it("returns a stable key for an anchor range", () => {
+    expect(getPreviewAnchorKey({ lineStart: 12, lineEnd: 16 })).toBe("12:16");
+  });
+});
 
 describe("findClosestPreviewAnchor", () => {
   const anchors = [

--- a/src/lib/preview-scroll.ts
+++ b/src/lib/preview-scroll.ts
@@ -3,6 +3,10 @@ export type PreviewScrollAnchor = {
   lineStart: number;
 };
 
+export function getPreviewAnchorKey(anchor: PreviewScrollAnchor) {
+  return `${anchor.lineStart}:${anchor.lineEnd}`;
+}
+
 export function findClosestPreviewAnchor<T extends PreviewScrollAnchor>(
   anchors: T[],
   activeLine: number | null,


### PR DESCRIPTION
## 배경 및 의도

편집 패널에서 타이핑할 때 미리보기 패널이 preview HTML 재렌더, 레이아웃 변경, 활성 줄 변경을 모두 스크롤 트리거로 해석하면서 스크롤 위치가 흔들리는 문제가 있었습니다.

이번 PR의 의도는 자동 스크롤 원칙을 더 좁고 예측 가능하게 만드는 것입니다. 편집창의 활성 줄이 실제 미리보기의 앵커 가능한 블록으로 바뀌었을 때만 미리보기 위치를 맞추고, 단순 렌더 갱신이나 사용자 수동 스크롤은 자동 스크롤과 충돌하지 않도록 정리했습니다.

## 변경사항

- 미리보기 스크롤 동기화 기준을 원시 line number에서 안정적인 anchor key로 변경했습니다.
- preview HTML 갱신만으로는 중복 스크롤하지 않되, 새 앵커가 렌더된 경우 한 프레임 뒤 활성 줄 기준으로 다시 동기화하도록 했습니다.
- 빠른 타이핑 중 발생하는 여러 스크롤 요청을 `requestAnimationFrame` 단위로 병합했습니다.
- 자동 스크롤은 즉시 이동인 `behavior: auto`를 사용해 smooth scroll 누적으로 인한 흔들림을 줄였습니다.
- wheel, pointer, touch, scroll 기반 수동 입력 후 짧은 시간 자동 스크롤을 억제하도록 했습니다.
- 프로그램 스크롤 이벤트가 수동 스크롤로 오인되거나, 반대로 실제 수동 의도를 프로그램 스크롤로 소비하는 경로를 방어했습니다.
- `docs/superpowers/specs/2026-05-22-preview-auto-scroll-design.md`와 `docs/superpowers/plans/2026-05-22-preview-auto-scroll.md`에 스펙과 실행 계획을 기록했습니다.
- `MarkdownPreview` 및 `preview-scroll` 테스트를 확장해 앵커 동기화, 렌더 갱신, RAF 병합, 수동 스크롤 억제, 프로그램 스크롤 구분을 검증했습니다.

## 변경으로 인한 영향

- 편집 중 미리보기는 활성 줄이 다른 앵커 블록으로 이동할 때만 따라갑니다.
- 같은 앵커 블록 내부에서 타이핑하거나 preview HTML만 갱신되는 경우 불필요한 스크롤 이동이 줄어듭니다.
- 사용자가 미리보기 패널을 직접 스크롤하는 동안에는 자동 동기화가 잠시 멈춰 읽기 흐름을 침범하지 않습니다.
- 기존 마크다운 렌더링, 링크 처리, 미디어 로딩 정책은 유지됩니다.
- 별도 마이그레이션이나 설정 변경은 없습니다.

## 의사결정과정

- 스크롤 비율 기반 동기화 대신 활성 줄 기반 앵커 동기화를 선택했습니다. 현재 제품의 핵심 요구가 편집 중 커서 주변 미리보기 확인에 가깝고, 비율 동기화는 긴 문서나 렌더 높이 차이가 큰 문서에서 실제 커서 문맥과 어긋날 수 있기 때문입니다.
- preview 재렌더를 스크롤 트리거로 직접 사용하지 않고, 앵커 갱신 후 예약된 동기화만 수행하도록 했습니다. 이 방식은 이미지 로딩이나 markdown debounce 같은 렌더 타이밍 차이를 흡수하면서도 중복 스크롤을 피합니다.
- smooth scroll은 자동 동기화 경로에서 제외했습니다. 타이핑처럼 빈번한 입력에서는 애니메이션 누적보다 즉시 위치 보정이 더 안정적입니다.
- 수동 스크롤 억제는 짧은 시간창으로 제한했습니다. 사용자의 읽기 의도를 존중하면서도 편집으로 돌아왔을 때 동기화가 영구히 끊기지 않게 하기 위한 절충입니다.

## 검증

- `npm run test -- src/lib/preview-scroll.test.ts src/components/preview/MarkdownPreview.test.tsx`
  - 미리보기 스크롤 관련 targeted suite 20개 테스트가 통과했습니다.
- `npm run test`
  - 전체 Vitest suite 197개 테스트가 통과했습니다.
- `npm run build`
  - TypeScript와 Vite 빌드가 통과했습니다. Vite의 chunk size warning만 기존처럼 출력됩니다.
- 수동 확인
  - 로컬 Vite 앱에서 새 Markdown 문서를 만들고 CodeMirror 입력, TOC/preview 갱신, unsaved 상태 변화를 확인했습니다.
- 코드 리뷰
  - 서브에이전트 리뷰에서 초기 중요 이슈 2건을 발견해 수정했습니다.
  - 최종 재리뷰 기준 blocking/important 이슈 없음, 이전 중요 이슈 resolved 판정을 받았습니다.

## 영향 범위에서 특히 확인할 점

- 긴 문서에서 빠르게 타이핑할 때 미리보기 패널이 불필요하게 흔들리지 않는지 확인해 주세요.
- 미리보기 패널을 수동으로 스크롤한 직후 자동 동기화가 사용자의 읽기 위치를 즉시 덮어쓰지 않는지 확인해 주세요.
- 이미지나 코드블록처럼 렌더 높이가 뒤늦게 바뀌는 블록 주변에서도 활성 줄 동기화가 한 번만 안정적으로 일어나는지 확인해 주세요.