### PR TITLE
feat(ci): GitHub Release 배포 워크플로 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test
+
+      - name: Build frontend
+        run: npm run build
+
+  rust:
+    name: Rust
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Install Tauri Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Check Rust crate
+        working-directory: src-tauri
+        run: cargo check --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to create or update, for example v0.1.0"
+        required: true
+        type: string
+      prerelease:
+        description: "Mark the GitHub Release as a prerelease"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref_name || inputs.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS Apple Silicon
+            platform: macos-latest
+            args: --target aarch64-apple-darwin
+          - name: macOS Intel
+            platform: macos-latest
+            args: --target x86_64-apple-darwin
+          - name: Linux
+            platform: ubuntu-22.04
+            args: ""
+          - name: Windows
+            platform: windows-latest
+            args: ""
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ startsWith(matrix.platform, 'macos') && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: Cache Rust dependencies
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build and upload release assets
+        uses: tauri-apps/tauri-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag_name }}
+          releaseName: ClipMark ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag_name }}
+          releaseBody: "Installers and bundles are attached to this release."
+          releaseDraft: true
+          prerelease: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}
+          generateReleaseNotes: true
+          tauriScript: npm run tauri
+          args: ${{ matrix.args }}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ npm run tauri:dev
 npm run dev
 ```
 
+## 배포
+
+GitHub Actions로 CI와 GitHub Release 배포를 구성합니다.
+
+- Pull request와 `main` 브랜치 push에서는 프론트엔드 테스트, 프론트엔드 빌드, Rust 체크를 실행합니다.
+- `v*` 형식의 태그를 push하면 macOS, Linux, Windows용 Tauri 번들을 빌드하고 GitHub Release draft에 업로드합니다.
+- GitHub Actions의 `Release` 워크플로를 수동 실행해 특정 태그로 릴리스를 만들 수도 있습니다.
+
+새 버전을 배포하려면 `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`의 버전을 맞춘 뒤 태그를 push합니다.
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+워크플로가 끝나면 GitHub Releases에서 draft를 확인하고 릴리스 노트와 첨부 파일을 검토한 뒤 게시합니다.
+
 ## 현재 범위
 
 ClipMark는 의도적으로 작습니다. 계정, 클라우드 동기화, 협업, 데이터베이스형 문서 관리, 블록 에디팅 같은 기능은 포함하지 않습니다. 문서는 사용자의 로컬 파일이며, 앱은 그 파일을 빠르게 열고 정리하고 저장하는 데 집중합니다.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,13 +10,15 @@ rust-version = "1.77.2"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-block2 = "0.6.2"
-objc2 = "0.6.4"
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSAlert", "NSApplication", "NSButton", "NSControl", "NSResponder", "NSView", "NSWindow"] }
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSString"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 url = "2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+block2 = "0.6.2"
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSAlert", "NSApplication", "NSButton", "NSControl", "NSResponder", "NSView", "NSWindow"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSString"] }


### PR DESCRIPTION
## 배경 및 의도

현재 ClipMark는 로컬에서 Tauri 앱을 빌드하고 실행하는 방법은 정리되어 있지만, GitHub Release를 통해 설치 파일을 배포하는 자동화 흐름은 없습니다. 릴리스마다 macOS, Linux, Windows 번들을 수동으로 빌드하고 첨부하면 플랫폼별 누락이나 버전 불일치가 생기기 쉽습니다.

이번 변경은 GitHub Actions를 통해 검증과 배포 경로를 분리하고, `v*` 태그를 기준으로 GitHub Release draft에 Tauri 번들을 모으는 기본 배포 파이프라인을 만드는 것이 목적입니다.

## 변경사항

- `.github/workflows/ci.yml`을 추가했습니다.
  - Pull request와 `main` 브랜치 push에서 실행됩니다.
  - 프론트엔드 의존성을 `npm ci`로 설치합니다.
  - `npm run test`로 Vitest 테스트를 실행합니다.
  - `npm run build`로 TypeScript와 Vite 프로덕션 빌드를 확인합니다.
  - Ubuntu runner에서 Tauri Linux 의존성을 설치한 뒤 `src-tauri`에서 `cargo check --locked`를 실행합니다.

- `.github/workflows/release.yml`을 추가했습니다.
  - `v*` 태그 push 또는 `workflow_dispatch` 수동 실행으로 동작합니다.
  - `tauri-apps/tauri-action@v1`을 사용해 Tauri 번들을 빌드하고 GitHub Release draft에 업로드합니다.
  - macOS Apple Silicon, macOS Intel, Linux, Windows 빌드를 matrix로 구성했습니다.
  - GitHub Release 생성과 asset 업로드를 위해 `contents: write` 권한을 설정했습니다.

- `README.md`에 배포 방법을 추가했습니다.
  - 버전을 맞춘 뒤 `git tag v0.1.0`, `git push origin v0.1.0`으로 배포를 시작하는 흐름을 문서화했습니다.
  - 워크플로 완료 후 GitHub Release draft를 검토하고 게시하는 단계를 명시했습니다.

## 변경으로 인한 영향

- PR과 `main` push에서 기본 품질 검증이 자동으로 수행됩니다.
- `v*` 태그를 push하면 GitHub Release draft가 생성되거나 갱신되고, 플랫폼별 Tauri 설치 번들이 첨부됩니다.
- 릴리스는 draft로 생성되므로, 자동 빌드가 끝난 뒤 사람이 릴리스 노트와 첨부 파일을 확인하고 게시할 수 있습니다.
- macOS 코드 서명이나 notarization은 이번 범위에 포함하지 않았습니다. 필요하면 별도 secret과 Tauri signing/notarization 설정을 추가해야 합니다.

## 의사결정과정

- 프로젝트의 기존 스크립트가 `npm` 중심이고 `package-lock.json`이 존재하므로 Actions에서도 `npm ci`를 사용했습니다.
- Tauri 프로젝트가 저장소 루트의 `src-tauri`에 있으므로 `tauriScript: npm run tauri`를 명시해 로컬 `@tauri-apps/cli` 스크립트를 사용하게 했습니다.
- 릴리스 워크플로는 즉시 공개 release를 만들지 않고 `releaseDraft: true`로 구성했습니다. 데스크톱 앱 배포에서는 설치 파일과 릴리스 노트를 사람이 확인하는 단계가 안전합니다.
- macOS는 Apple Silicon과 Intel을 나눠 빌드하도록 matrix를 구성했습니다. 사용자가 실제로 받을 설치 파일의 아키텍처가 명확해지고, Rosetta 의존을 줄일 수 있습니다.

## 검증

- `npm run test`
  - 57개 test file, 197개 test 통과
- `npm run build`
  - TypeScript/Vite 프로덕션 빌드 통과
- `cargo check --locked`
  - `src-tauri` Rust crate 체크 통과
- `.github/workflows/ci.yml`, `.github/workflows/release.yml`
  - 로컬 YAML 파싱 확인

## 영향 범위에서 특히 확인할 점

- 첫 태그 배포 시 GitHub Actions runner에서 Linux Tauri 시스템 의존성 설치가 정상 동작하는지 확인이 필요합니다.
- macOS 배포 품질을 높이려면 이후 코드 서명, notarization, updater 서명 여부를 별도 범위로 결정해야 합니다.
- 현재 Release는 draft로 생성되므로, 워크플로 성공 후 GitHub Releases 화면에서 수동 게시가 필요합니다.