### PR TITLE
fix(release): Tauri Action 버전 참조 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         run: npm ci
 
       - name: Build and upload release assets
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## 배경 및 의도

v0.1.0 태그 푸시로 실행된 Release workflow가 모든 매트릭스 job에서 빌드 단계에 진입하기 전에 실패했습니다. 실패 지점은 앱 빌드나 번들링이 아니라 GitHub Actions가 `tauri-apps/tauri-action@v1` 액션을 해석하는 준비 단계였습니다.

실패 로그에는 `Unable to resolve action tauri-apps/tauri-action@v1, unable to find version v1`가 기록되어 있었고, 원격 저장소의 실제 태그를 확인한 결과 `v1` ref는 존재하지 않았습니다. 릴리스 워크플로가 다시 액션 다운로드 단계를 통과하도록 실제 존재하는 태그로 고정하는 것이 목적입니다.

## 변경사항

- `.github/workflows/release.yml`의 Tauri Action 참조를 `tauri-apps/tauri-action@v1`에서 `tauri-apps/tauri-action@v0.6.2`로 변경했습니다.
- `v0.6.2`는 `tauri-apps/tauri-action` 원격 저장소에서 실제 조회되는 태그입니다.

## 변경으로 인한 영향

Release workflow가 GitHub Actions 준비 단계에서 존재하지 않는 액션 버전 때문에 즉시 실패하던 문제를 해소합니다. 이후 릴리스 실행에서는 액션 다운로드 이후의 실제 Tauri 빌드, 번들링, 릴리스 asset 업로드 단계까지 진행될 수 있습니다.

이번 변경은 릴리스 CI 설정 한 줄에 한정되며 애플리케이션 런타임 코드, Tauri 설정, 패키지 의존성에는 영향을 주지 않습니다. 다만 이 문제 뒤에 가려져 있던 플랫폼별 번들링 오류가 다음 실행에서 새로 드러날 가능성은 있습니다.

## 의사결정과정

처음에는 실패한 run의 로그를 확인해 모든 플랫폼 job이 같은 지점에서 실패한다는 점을 확인했습니다. 공통 실패가 `Set up job`의 액션 다운로드 단계였기 때문에 플랫폼별 빌드 환경이나 소스 코드 문제가 아니라 workflow의 `uses` ref 문제로 판단했습니다.

`tauri-apps/tauri-action` 원격 태그를 조회해 `v1`이 존재하지 않고 `v0.6.2`가 존재함을 확인했습니다. 릴리스 워크플로 안정성을 위해 브랜치나 문서 예시가 아닌 실제 태그로 고정했습니다.

## 검증

- `git ls-remote --exit-code --tags https://github.com/tauri-apps/tauri-action.git refs/tags/v0.6.2`: 변경된 액션 ref가 원격 태그로 존재함을 확인했습니다.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml YAML parsed"'`: Release workflow YAML 파싱이 성공함을 확인했습니다.
- `npm run build`: 프론트엔드 TypeScript/Vite production build가 성공함을 확인했습니다. Vite의 500kB 초과 chunk 경고는 기존 번들 크기 경고이며 이번 workflow 변경과 직접 관련 없습니다.
