### PR TITLE
fix(macos): Markdown 문서 연결 설정 보강

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1098,6 +1098,16 @@ mod tests {
             .expect("markdown association should declare content types")
             .iter()
             .any(|content_type| content_type == "net.daringfireball.markdown"));
+        assert_eq!(markdown["mimeType"], "text/markdown");
+        assert_eq!(
+            markdown["exportedType"]["identifier"],
+            "net.daringfireball.markdown"
+        );
+        assert!(markdown["exportedType"]["conformsTo"]
+            .as_array()
+            .expect("markdown exported type should declare parent types")
+            .iter()
+            .any(|content_type| content_type == "public.plain-text"));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,10 +35,15 @@
         "name": "Markdown Document",
         "description": "Markdown document",
         "contentTypes": [
-          "net.daringfireball.markdown",
-          "public.plain-text"
+          "net.daringfireball.markdown"
         ],
         "mimeType": "text/markdown",
+        "exportedType": {
+          "identifier": "net.daringfireball.markdown",
+          "conformsTo": [
+            "public.plain-text"
+          ]
+        },
         "role": "Editor",
         "rank": "Owner"
       }


### PR DESCRIPTION
## 작업 배경 및 의도
macOS에서 .md 파일의 권장 응용 프로그램 목록에 ClipMark가 표시되지 않는 문제가 있었습니다. Tauri 번들 설정이 Markdown 문서 타입을 편집 대상으로 선언하고 있었지만, macOS Launch Services가 참조하는 Markdown UTI 선언이 충분히 명확하지 않아 앱 매칭이 약했습니다.

## 작업 목표
- ClipMark가 .md 및 .markdown 문서를 열 수 있는 편집 앱으로 안정적으로 등록되도록 합니다.
- 이후 설정 회귀가 발생하지 않도록 Tauri 설정 검증 범위를 넓힙니다.

## 변경사항
- Markdown 파일 연결의 contentTypes를 net.daringfireball.markdown으로 명확히 지정했습니다.
- macOS UTExportedTypeDeclarations로 변환되는 exportedType을 추가했습니다.
- exportedType이 public.plain-text를 상속하도록 선언했습니다.
- Tauri 설정 검증 테스트가 mimeType과 exportedType까지 확인하도록 확장했습니다.

## 영향
- macOS 번들 생성 후 .md 파일의 권장 응용 프로그램 후보로 ClipMark가 더 안정적으로 표시됩니다.
- 기존 문서 열기, 저장, 창 관리 로직에는 동작 변경이 없습니다.

## 테스트
- npm run build
- npm run test

## 참고
- 로컬 Codex 환경에는 cargo/rustc가 없어 npm run tauri:build는 여기서 실행하지 못했습니다. 사용자가 Rust 툴체인이 있는 로컬 환경에서 확인했습니다.