### PR TITLE
build(release): macOS 범용 앱 배포로 전환

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: macOS Apple Silicon
+          - name: macOS Universal
             platform: macos-latest
-            args: --target aarch64-apple-darwin
-          - name: macOS Intel
-            platform: macos-latest
-            args: --target x86_64-apple-darwin
+            args: --target universal-apple-darwin
           - name: Linux
             platform: ubuntu-22.04
             args: ""

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "icon:gen": "npm run tauri icon",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:build": "tauri build",
+    "tauri:build:macos:universal": "tauri build --target universal-apple-darwin"
   },
   "dependencies": {
     "@codemirror/lang-markdown": "^6.3.3",


### PR DESCRIPTION
## 배경 및 의도
Apple Silicon 환경에서 Intel 전용 앱은 Rosetta에 의존합니다. Rosetta 지원 축소에 대비하고, 사용자가 macOS 릴리스 산출물을 선택할 때 Intel/Apple Silicon 개별 DMG 중 잘못된 파일을 받는 혼란을 줄이기 위해 macOS 배포물을 범용 앱으로 전환합니다.

## 목표
하나의 macOS DMG가 Intel Mac과 Apple Silicon Mac에서 모두 실행되도록 release 워크플로를 정리합니다.

## 변경사항
- macOS 릴리스 matrix를 Apple Silicon/Intel 개별 빌드에서 macOS Universal 단일 빌드로 변경했습니다.
- Tauri macOS 릴리스 타깃을 `universal-apple-darwin`으로 변경했습니다.
- 로컬 검증용 `npm run tauri:build:macos:universal` 스크립트를 추가했습니다.

## 영향
- GitHub Release에는 macOS universal DMG가 생성됩니다.
- Apple Silicon Mac에서는 Rosetta 없이 네이티브 arm64 슬라이스로 실행됩니다.
- Intel Mac도 같은 앱의 x86_64 슬라이스로 계속 실행할 수 있습니다.
- Linux와 Windows 릴리스 빌드에는 영향이 없습니다.

## 테스트
- `rustup target add x86_64-apple-darwin`
- `npm run tauri:build:macos:universal -- --bundles app`
- `lipo -archs src-tauri/target/universal-apple-darwin/release/bundle/macos/ClipMark.app/Contents/MacOS/clipmark` 결과: `x86_64 arm64`
- `npm run tauri:build:macos:universal`
