### PR TITLE
fix(release): 준비 스크립트 출력과 실패 복구 개선

### DIFF
--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -39,6 +39,28 @@ function run(command, args, options = {}) {
     encoding: "utf8",
     stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
   });
+}
+
+function createVersionFileBackup() {
+  return new Map(
+    VERSION_FILES.map(path => [
+      path,
+      existsSync(path) ? readFileSync(path, "utf8") : undefined,
+    ]),
+  );
+}
+
+function restoreVersionFileBackup(backup) {
+  for (const [path, content] of backup) {
+    if (content !== undefined) {
+      writeFileSync(path, content);
+    }
+  }
+  try {
+    run("git", ["reset", "--", ...VERSION_FILES]);
+  } catch {
+    // Best effort cleanup; the original error should remain the visible failure.
+  }
 }
 
 function assertCleanWorkingTree() {
@@ -86,8 +108,8 @@ async function updateVersionFiles(version) {
 }
 
 function commitAndTag({ tagName, version }) {
-  run("git", ["diff", "--check"], { stdio: "inherit" });
-  run("git", ["add", ...VERSION_FILES], { stdio: "inherit" });
+  run("git", ["diff", "--check"]);
+  run("git", ["add", ...VERSION_FILES]);
 
   const messagePath = join(mkdtempSync(join(tmpdir(), "clipmark-release-")), "commit-message.txt");
   writeFileSync(
@@ -100,8 +122,8 @@ function commitAndTag({ tagName, version }) {
     ].join("\n"),
   );
 
-  run("git", ["commit", "--file", messagePath], { stdio: "inherit" });
-  run("git", ["tag", tagName], { stdio: "inherit" });
+  run("git", ["commit", "--quiet", "--file", messagePath]);
+  run("git", ["tag", tagName]);
 }
 
 async function main() {
@@ -114,10 +136,31 @@ async function main() {
   const release = normalizeReleaseVersion(versionArg);
   assertCleanWorkingTree();
   assertTagDoesNotExist(release.tagName);
-  await updateVersionFiles(release.version);
-  commitAndTag(release);
 
-  console.log("");
+  const backup = createVersionFileBackup();
+  let committed = false;
+  const restoreOnInterrupt = () => {
+    if (!committed) {
+      restoreVersionFileBackup(backup);
+    }
+    process.exit(130);
+  };
+
+  process.once("SIGINT", restoreOnInterrupt);
+  process.once("SIGTERM", restoreOnInterrupt);
+
+  try {
+    await updateVersionFiles(release.version);
+    commitAndTag(release);
+    committed = true;
+  } catch (error) {
+    restoreVersionFileBackup(backup);
+    throw error;
+  } finally {
+    process.removeListener("SIGINT", restoreOnInterrupt);
+    process.removeListener("SIGTERM", restoreOnInterrupt);
+  }
+
   console.log(`Prepared release ${release.tagName}.`);
   console.log(`Push with: git push origin HEAD ${release.tagName}`);
 }


### PR DESCRIPTION
## 개요

`npm run release:prepare -- <version>` 실행 중 터미널에 `git commit` 출력이 그대로 노출되고, 실패나 중단 시 버전 파일 변경이 남을 수 있던 문제를 정리합니다.

## 변경 사항

- `git diff`, `git add`, `git commit`, `git tag` 실행 출력을 스크립트 내부에서 제어해 성공 시 필요한 두 줄만 출력하도록 했습니다.
- 버전 파일 변경 전 원본 내용을 백업하고, 커밋/태그 생성 중 실패하면 `package.json`, `package-lock.json`, `src-tauri/tauri.conf.json`을 복구합니다.
- 실패 복구 시 Git index도 `git reset -- <version files>`로 정리해 staged 변경이 남지 않게 했습니다.
- `SIGINT`, `SIGTERM` 중단 시에도 커밋 전이면 버전 파일을 복구하도록 했습니다.

## 검증

- `node --check scripts/prepare-release.mjs`: 스크립트 문법 검증
- 임시 Git 저장소에서 `scripts/prepare-release.mjs 9.8.9` 실행: 출력이 `Prepared release ...`, `Push with ...` 두 줄로 정리되는지 확인
- 임시 Git 저장소에서 실패하는 `pre-commit` hook 구성 후 실행: 실패 뒤 버전 파일과 Git index가 원래 상태로 복구되는지 확인
