### PR TITLE
fix(release): Windows 버전 검증 셸 고정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
         run: npm ci
 
       - name: Verify release version
+        shell: bash
         env:
           TAG_NAME: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag_name }}
         run: |


### PR DESCRIPTION
## 개요

Windows release job의 `Verify release version` 단계가 PowerShell에서 Bash 스크립트를 파싱하다 실패한 문제를 수정합니다.

## 원인

실패한 job 로그에서 Windows runner는 해당 step을 기본 셸인 `pwsh`로 실행했습니다.

```text
shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
ParserError: Missing '(' after 'if' in if statement.
```

하지만 step 스크립트는 `VERSION="${TAG_NAME#v}"`, `if ! ...; then`, heredoc 같은 Bash 문법으로 작성되어 있습니다. macOS/Linux job은 기본 Bash 계열 셸이라 통과했지만, Windows job에서는 PowerShell 문법으로 해석되어 실패했습니다.

## 변경 사항

- `Verify release version` step에 `shell: bash`를 명시했습니다.
- Windows runner에서도 Git Bash로 같은 스크립트를 실행하도록 고정했습니다.

## 검증

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml OK"'`: release workflow YAML 파싱 확인
- `git diff --check`: whitespace 오류 없음 확인
