### PR TITLE
fix(release): 단일 publish job으로 릴리스 업로드 통합

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,31 +138,19 @@ jobs:
 
       - name: Build and upload macOS release assets
         if: startsWith(matrix.platform, 'macos')
-        uses: tauri-apps/tauri-action@v0.6.2
+        run: npm run tauri:build -- ${{ matrix.args }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
-        with:
-          tagName: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag_name }}
-          releaseName: ClipMark ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag_name }}
-          releaseBody: "Installers and bundles are attached to this release."
-          releaseDraft: true
-          prerelease: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}
-          generateReleaseNotes: true
-          tauriScript: npm run tauri
-          args: ${{ matrix.args }}
 
-      - name: Notarize and replace macOS DMG release asset
+      - name: Notarize macOS DMG
         if: startsWith(matrix.platform, 'macos')
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          TAG_NAME: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag_name }}
         run: |
           DMG_PATH=$(find src-tauri/target -path '*/release/bundle/dmg/*.dmg' -type f | head -1)
           if [ -z "$DMG_PATH" ]; then
@@ -175,24 +163,83 @@ jobs:
           xcrun stapler staple "$DMG_PATH"
           xcrun stapler validate "$DMG_PATH"
           spctl --assess --type open --context context:primary-signature --verbose "$DMG_PATH"
-          gh release upload "$TAG_NAME" "$DMG_PATH" --clobber
 
-      - name: Build and upload non-macOS release assets
-        if: ${{ !startsWith(matrix.platform, 'macos') }}
-        uses: tauri-apps/tauri-action@v0.6.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload macOS artifact
+        if: startsWith(matrix.platform, 'macos')
+        uses: actions/upload-artifact@v4
         with:
-          tagName: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag_name }}
-          releaseName: ClipMark ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag_name }}
-          releaseBody: "Installers and bundles are attached to this release."
-          releaseDraft: true
-          prerelease: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}
-          generateReleaseNotes: true
-          tauriScript: npm run tauri
-          args: ${{ matrix.args }}
+          name: macos-dmg
+          path: src-tauri/target/**/release/bundle/dmg/*.dmg
+          if-no-files-found: error
+
+      - name: Build non-macOS release assets
+        if: ${{ !startsWith(matrix.platform, 'macos') }}
+        run: npm run tauri:build -- ${{ matrix.args }}
+
+      - name: Upload Linux artifacts
+        if: matrix.platform == 'ubuntu-22.04'
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-installers
+          path: |
+            src-tauri/target/**/release/bundle/appimage/*.AppImage
+            src-tauri/target/**/release/bundle/deb/*.deb
+            src-tauri/target/**/release/bundle/rpm/*.rpm
+          if-no-files-found: error
+
+      - name: Upload Windows artifact
+        if: matrix.platform == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: src-tauri/target/**/release/bundle/nsis/*setup.exe
+          if-no-files-found: error
 
       - name: Cleanup Apple certificate
         if: startsWith(matrix.platform, 'macos') && always()
         run: |
           security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" || true
+
+  publish:
+    name: Publish Release
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Publish release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag_name }}
+          PRERELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}
+        run: |
+          mkdir -p upload
+          find release-artifacts -type f \( \
+            -name '*.dmg' -o \
+            -name '*setup.exe' -o \
+            -name '*.AppImage' -o \
+            -name '*.deb' -o \
+            -name '*.rpm' \
+          \) -exec cp {} upload/ \;
+
+          if [ -z "$(find upload -type f -print -quit)" ]; then
+            echo "::error::No release assets were downloaded."
+            find release-artifacts -type f -print
+            exit 1
+          fi
+
+          find upload -maxdepth 1 -type f -print | sort
+
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            gh release upload "$TAG_NAME" upload/* --clobber
+          else
+            args=(release create "$TAG_NAME" upload/* --title "ClipMark $TAG_NAME" --notes "Installers are attached to this release." --draft)
+            if [ "$PRERELEASE" = "true" ]; then
+              args+=(--prerelease)
+            fi
+            gh "${args[@]}"
+          fi

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ npm run dev
 GitHub Actions로 CI와 GitHub Release 배포를 구성합니다.
 
 - Pull request와 `main` 브랜치 push에서는 프론트엔드 테스트, 프론트엔드 빌드, Rust 체크를 실행합니다.
-- `v*` 형식의 태그를 push하면 macOS, Linux, Windows용 Tauri 번들을 빌드하고 GitHub Release draft에 업로드합니다.
+- `v*` 형식의 태그를 push하면 macOS, Linux, Windows용 Tauri 번들을 빌드하고 단일 GitHub Release draft에 업로드합니다.
 - macOS 번들은 Developer ID로 서명하고, `.app`과 `.dmg`를 공증한 뒤 stapling합니다.
+- 공개 Release asset은 macOS `.dmg`, Windows `setup.exe`, Linux `.AppImage`/`.deb`/`.rpm`만 업로드합니다.
 - GitHub Actions의 `Release` 워크플로를 수동 실행해 특정 태그로 릴리스를 만들 수도 있습니다.
 
 릴리스 전 GitHub 저장소 secrets에 아래 값이 있어야 합니다.


### PR DESCRIPTION
## 개요

OS별 matrix job이 각각 GitHub Release를 직접 만지면서 같은 태그의 Release/Draft가 여러 개 생기던 문제를 해결합니다.

각 OS job은 이제 설치 파일을 GitHub Actions artifact로만 업로드하고, 마지막 `Publish Release` job 하나가 모든 artifact를 모아 단일 GitHub Release에 업로드합니다.

## 배경

`v0.1.3` release workflow에서는 macOS Universal, Linux, Windows job이 모두 성공했지만 공개된 `v0.1.3` Release에는 Linux 산출물만 보였습니다. 확인 결과 macOS `.dmg`와 Windows installer는 별도 draft Release에 업로드되어 있었습니다.

원인은 matrix job마다 `tauri-apps/tauri-action`의 release 업로드 기능을 사용해 병렬로 Release를 생성/갱신한 점입니다. `releaseDraft: true` 상태에서 job들이 동시에 같은 태그를 다루면서 asset이 여러 draft/release로 분리됐습니다.

## 변경 사항

- matrix build job에서는 더 이상 GitHub Release를 생성하거나 갱신하지 않습니다.
- macOS job은 `npm run tauri:build -- --target universal-apple-darwin`로 빌드하고 DMG 공증/stapling 후 `.dmg`만 artifact로 업로드합니다.
- Linux job은 `.AppImage`, `.deb`, `.rpm`만 artifact로 업로드합니다.
- Windows job은 `setup.exe`만 artifact로 업로드합니다.
- `Publish Release` job을 추가해 모든 artifact를 다운로드한 뒤 단일 GitHub Release에 업로드합니다.
- 이미 해당 태그의 Release가 있으면 `gh release upload --clobber`로 교체하고, 없으면 draft Release를 생성합니다.
- README의 배포 설명을 단일 Release와 공개 asset 정책에 맞게 갱신했습니다.

## 영향

- GitHub Release 페이지 하나에 macOS `.dmg`, Windows `setup.exe`, Linux `.AppImage`/`.deb`/`.rpm`가 함께 표시됩니다.
- `.app.tar.gz`, `.msi`는 공개 Release asset에서 제외됩니다.
- Release 생성/업로드가 한 job으로 모여 matrix 병렬 실행에 따른 draft 분산 문제가 없어집니다.

## 검증

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml OK"'`: release workflow YAML 파싱 확인
- `git diff --check`: whitespace 오류 없음 확인
