### PR TITLE
fix(release): publish job 저장소 컨텍스트 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,9 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
@@ -214,6 +217,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag_name }}
           PRERELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}
         run: |


### PR DESCRIPTION
## 변경 내용

- `publish` job에 `actions/checkout@v4`를 추가했습니다.
- `gh release` 명령이 저장소를 확실히 찾도록 `GH_REPO`를 명시했습니다.

## 원인

`publish release assets` 단계에서 산출물은 정상적으로 수집됐지만, `publish` job에는 checkout 단계가 없어 `.git` 디렉터리가 없었습니다. 이 상태에서 `gh release view/upload/create`가 현재 저장소를 추론하려다 `fatal: not a git repository`로 실패했습니다.

## 검증

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml OK"'`
- `git diff --check`
